### PR TITLE
Integrate Web Components support and enhance documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Start the dev server
 $ php -S localhost:5000 -t <path-to-project>
 ```
 
+### Server-rendered UI, HTMX, and Web Components
+
+Assegai is not JSON-only. The framework supports classic server-rendered views through `view(...)`, component-backed pages through `render(...)`, automatic HTMX inclusion in rendered HTML, and first-class Web Components hydration through safe `data-props` helpers plus automatic bundle injection.
+
+For the full walkthrough, see [Pages and Components](./docs/pages-and-components.md).
+
 ### Constrained Route Params
 
 Assegai routes support constrained dynamic params using angle-bracket syntax:

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ The goal is to show how Assegai helps you move quickly without giving up structu
 3. [Architecture and Lifecycle](./architecture-and-lifecycle.md)
 4. [Controllers and Routing](./controllers-and-routing.md)
 5. [Modules and Providers](./modules-and-providers.md)
-6. [Pages and Components](./pages-and-components.md)
+6. [Pages, Components, HTMX, and Web Components](./pages-and-components.md)
 7. [Guards, Interceptors, Pipes, and Middleware](./guards-interceptors-pipes-and-middleware.md)
 8. [Data and ORM](./data-and-orm.md)
 9. [Queues and Background Jobs](./queues-and-background-jobs.md)
@@ -63,7 +63,7 @@ Assegai is easiest to understand when you see it as a few cooperating concepts:
 - providers hold application logic
 - DTOs shape input
 - entities shape persistence
-- declarations and components shape rendered pages
+- declarations, HTMX, and Web Components shape rendered pages
 - responders turn handler return values into JSON or HTML
 - the CLI keeps those conventions easy to create and maintain
 

--- a/docs/pages-and-components.md
+++ b/docs/pages-and-components.md
@@ -1,15 +1,43 @@
 # Pages and Components
 
-Assegai can serve JSON APIs, but it also supports server-rendered pages. Two rendering styles are visible in the framework today:
+Assegai is not limited to JSON APIs. The rendering stack already supports a practical server-first UI model built from four pieces that work well together:
 
-- classic view rendering with `View`
-- component-backed page rendering with declarations and `AssegaiComponent`
+- classic `View` rendering for straightforward templates
+- component-backed pages built from module declarations and `AssegaiComponent`
+- HTMX, which is injected automatically into rendered HTML pages
+- Web Components, which can be rendered on the server and hydrated in the browser
 
-Understanding both is useful because the starter app and the page generator demonstrate different parts of the rendering stack.
+The important idea is that Assegai treats HTML as a first-class response type. You can start with server-rendered pages, add HTMX where interaction helps, and introduce Web Components when a custom element earns its keep.
 
-## The starter app uses a classic view
+## Choose the simplest rendering shape that fits
 
-The scaffolded home page returns a `View` from `AppService`:
+Use a classic `View` when:
+
+- the page is mostly a template and some data
+- you want the shortest path from controller or service to HTML
+- the page already belongs under `src/Views`
+
+Use a component-backed page when:
+
+- the page belongs to a feature module
+- template, styles, controller, and service should live together
+- you want declarations to participate in the module graph
+
+Add HTMX when:
+
+- you want progressive enhancement without committing to a SPA
+- user actions should fetch or swap HTML over HTTP
+- the page already works server-side and just needs more interactivity
+
+Add Web Components when:
+
+- a piece of UI benefits from browser lifecycle hooks
+- you want reusable custom elements across pages or features
+- the server should still own the initial HTML shape and data
+
+## Classic views are the fastest path to HTML
+
+The scaffolded starter app uses a `View`:
 
 ```php
 <?php
@@ -42,23 +70,23 @@ class AppService
 }
 ```
 
-That `view('index', ...)` helper looks for templates under `src/Views`, so the starter page lives at:
+That helper resolves templates from:
 
 ```text
-src/Views/index.php
+src/Views/
 ```
 
-Use this path when you want a straightforward server-rendered page without introducing a dedicated component.
+This is the right fit when you want plain server-rendered HTML without introducing a dedicated feature module.
 
-## Generated pages use declarations and components
+## Component-backed pages give UI a feature boundary
 
-When you run:
+When you generate a page:
 
 ```bash
 assegai g pg about
 ```
 
-the generator creates:
+the CLI creates a feature folder like this:
 
 ```text
 src/About/
@@ -70,9 +98,9 @@ src/About/
 └── AboutService.php
 ```
 
-This is a different rendering model from the starter home page.
+That page is rendered through the same module system that organizes controllers and providers.
 
-## The generated module declares the component
+### The module declares the page component
 
 ```php
 <?php
@@ -91,9 +119,9 @@ readonly class AboutModule
 }
 ```
 
-The key new idea here is `declarations`. This is how the module makes the component part of the rendering graph.
+`declarations` is the key piece. It tells Assegai which UI components belong to the module's rendering graph.
 
-## The generated service returns a component
+### The service returns a rendered component
 
 ```php
 <?php
@@ -113,9 +141,11 @@ class AboutService
 }
 ```
 
-The `render()` helper constructs the component for you through the component factory and DI container.
+The `render()` helper resolves the component through the container and hands it to the HTML responder.
 
-## The component itself is explicit
+### The generated component is server-rendered
+
+With the current generator defaults, the component selector is prefixed:
 
 ```php
 <?php
@@ -126,7 +156,7 @@ use Assegai\Core\Attributes\Component;
 use Assegai\Core\Components\AssegaiComponent;
 
 #[Component(
-  selector: 'about',
+  selector: 'app-about',
   templateUrl: './AboutComponent.twig',
   styleUrls: ['./AboutComponent.css'],
 )]
@@ -136,49 +166,211 @@ class AboutComponent extends AssegaiComponent
 }
 ```
 
-And the template is small and focused:
+And the template stays simple:
 
 ```twig
 <p>{{ name }} works!</p>
 ```
 
-## How page rendering flows
+## HTMX is available on rendered pages out of the box
+
+Both of Assegai's HTML rendering paths inject HTMX automatically. That means server-rendered pages can start using `hx-*` attributes immediately without any extra setup step in your layout.
+
+For example, a component template can progressively enhance a normal page section:
+
+```twig
+<section>
+  <button
+    hx-get="/about/team"
+    hx-target="#team-panel"
+    hx-swap="innerHTML"
+  >
+    Load team details
+  </button>
+
+  <div id="team-panel">
+    <p>Team details will load here.</p>
+  </div>
+</section>
+```
+
+Assegai does not force an SPA-style rendering model here. The page is still server-rendered first, and HTMX becomes an opt-in enhancement on top.
+
+## Web Components now fit naturally into the rendering story
+
+Server-rendered HTML and custom elements are a good match. Assegai's Web Components support is built around that idea:
+
+- render a custom element tag from Twig or a PHP view
+- pass props from PHP into a safe `data-props` attribute
+- let the browser hydrate that element once the module bundle loads
+
+### Twig templates get a safe props helper
+
+Inside Twig component templates, use `ctx.webComponentProps(...)`:
+
+```twig
+<app-user-card data-props='{{ ctx.webComponentProps({
+  name: name,
+  quote: quote
+}) }}'>
+  <p>{{ name }}</p>
+</app-user-card>
+```
+
+This helper returns JSON escaped for use inside an HTML attribute, so quotes and markup in the payload do not break the page.
+
+### PHP views can use the same pattern
+
+In a classic PHP view, use the global helper directly:
+
+```php
+<app-user-card
+  data-props='<?= web_component_props([
+    "name" => $name,
+    "quote" => $quote,
+  ]) ?>'
+></app-user-card>
+```
+
+### The bundle is injected automatically when available
+
+Assegai looks for a Web Components bundle and injects a module script tag into rendered HTML when it resolves one.
+
+The default browser URL is:
+
+```text
+/js/assegai-components.min.js
+```
+
+So if this file exists:
+
+```text
+public/js/assegai-components.min.js
+```
+
+it will be included automatically.
+
+You can also configure the bundle explicitly in `assegai.json`:
+
+```json
+{
+  "webComponents": {
+    "enabled": true,
+    "output": "public/js/assegai-components.min.js"
+  }
+}
+```
+
+The runtime currently recognizes these keys:
+
+- `enabled`
+- `bundleUrl`
+- `bundlePath`
+- `output`
+
+Use `enabled: false` to disable automatic injection entirely.
+
+### Helpful runtime helpers are available
+
+Assegai exposes small helpers around the bundle and prop encoding:
+
+```php
+web_component_props($props);
+web_component_bundle_url();
+web_component_bundle_tag();
+```
+
+Inside Twig component templates, these are surfaced through `ctx`:
+
+```twig
+{{ ctx.webComponentProps({ name: name }) }}
+{{ ctx.webComponentBundleUrl() }}
+```
+
+In most apps you will not need to call `web_component_bundle_tag()` manually because the default HTML renderers already append it for you.
+
+## HTMX and Web Components complement each other well
+
+These tools are solving different parts of the same problem:
+
+- HTMX is great at asking the server for more HTML
+- Web Components are great at owning client-side behavior for a specific custom element
+
+That makes this a natural combination:
+
+1. the server renders an initial page
+2. HTMX swaps in more HTML later
+3. that HTML can include custom elements such as `<app-user-card>`
+4. once the module bundle is loaded, the browser upgrades those elements
+
+You do not need to choose one or the other for the whole application.
+
+## The CLI workflow now supports paired Web Components
+
+With the current `assegaiphp/console` support, you can keep the server-rendered feature structure and add browser-side elements where useful.
+
+Generate a standalone Web Component:
+
+```bash
+assegai g wc ui/alert
+```
+
+Pair a generated component or page with a `.wc.ts` runtime file:
+
+```bash
+assegai g component user-card --wc
+assegai g pg about --wc
+```
+
+Build or inspect the discovered components:
+
+```bash
+assegai wc:build
+assegai wc:watch
+assegai wc:list
+```
+
+The default build target is:
+
+```text
+public/js/assegai-components.min.js
+```
+
+which lines up with the automatic bundle detection in `assegaiphp/core`.
+
+The CLI side of the workflow is driven by `assegai.json`:
+
+```json
+{
+  "webComponents": {
+    "prefix": "app",
+    "output": "public/js/assegai-components.min.js",
+    "buildOnDumpAutoload": false
+  }
+}
+```
+
+Use `prefix` to control generated selectors such as `app-about` and `app-user-card`. Use `output` to control where the bundle is written. If you want the bundle rebuilt as part of `assegai dump-autoload`, set `buildOnDumpAutoload` to `true`.
+
+## How the full rendering flow fits together
 
 ```mermaid
 flowchart LR
   A["GET /about"] --> B["AboutController"]
   B --> C["AboutService"]
   C --> D["render(AboutComponent::class)"]
-  D --> E["ComponentResponder"]
-  E --> F["Template engine"]
-  F --> G["HTML response"]
+  D --> E["DefaultTemplateEngine"]
+  E --> F["Twig template"]
+  F --> G["HTML document"]
+  G --> H["HTMX script injected"]
+  G --> I["Web Components bundle injected when available"]
+  I --> J["Custom elements hydrate in the browser"]
 ```
 
-This is useful because it gives you a modular page system, not just a loose collection of template files.
+## A good default way to think about it
 
-## When to use a view vs a component
+Start with server-rendered HTML.
 
-Use a classic `View` when:
+Reach for a classic `View` when the page is simple. Reach for a component-backed page when the feature deserves its own boundary. Add HTMX when interactions should request HTML over HTTP. Add Web Components when a specific element needs browser-side lifecycle and behavior.
 
-- the page is small
-- you already have a template in `src/Views`
-- you want a very direct controller/service/template flow
-
-Use a generated page component when:
-
-- the page is feature-owned and deserves its own module
-- you want template, styles, service, and route kept together
-- you want the page to participate in the declarations system
-
-## Why this matters
-
-The page generator shows that Assegai's architecture is not API-only. The same module system that organizes controllers and providers also organizes rendered UI.
-
-That means a single Assegai app can comfortably combine:
-
-- REST endpoints
-- admin pages
-- marketing pages
-- hybrid API + HTML workflows
-
-without splitting into separate applications too early.
+That keeps Assegai in its strongest shape: server-first, modular, progressively enhanced, and still comfortable to grow.

--- a/src/Rendering/Engines/DefaultTemplateEngine.php
+++ b/src/Rendering/Engines/DefaultTemplateEngine.php
@@ -8,6 +8,7 @@ use Assegai\Core\Exceptions\RenderingException;
 use Assegai\Core\Http\Requests\Request;
 use Assegai\Core\Injector;
 use Assegai\Core\ModuleManager;
+use Assegai\Core\WebComponents\WebComponentSupport;
 use Assegai\Core\Routing\Router;
 use Assegai\Util\Path;
 use DateInvalidTimeZoneException;
@@ -24,6 +25,7 @@ use Twig\Extra\Markdown\DefaultMarkdown;
 use Twig\Extra\Markdown\MarkdownExtension;
 use Twig\Extra\Markdown\MarkdownRuntime;
 use Twig\Loader\FilesystemLoader;
+use Twig\Markup;
 use Twig\RuntimeLoader\RuntimeLoaderInterface;
 
 /**
@@ -184,6 +186,14 @@ class DefaultTemplateEngine extends TemplateEngine
       $ctx->addMethod('getLang', fn() => Request::getInstance()->getLang());
     }
 
+    if (!method_exists($ctx, 'webComponentProps')) {
+      $ctx->addMethod('webComponentProps', fn(mixed $props = []) => new Markup(web_component_props($props), 'UTF-8'));
+    }
+
+    if (!method_exists($ctx, 'webComponentBundleUrl')) {
+      $ctx->addMethod('webComponentBundleUrl', fn() => web_component_bundle_url());
+    }
+
     $data['ctx'] = $ctx;
 
     foreach ($componentReflection->getProperties() as $reflectionProperty) {
@@ -230,6 +240,7 @@ PROPS;
     $props .= $this->loadScripts();
     $output = $template->render([...$this->data]);
     $charSet = $this->meta['charset'] ?? 'UTF-8';
+    $webComponentBundleTag = $this->loadWebComponentBundle();
 
     return <<<START
 <!DOCTYPE html>
@@ -243,6 +254,7 @@ PROPS;
   </head>
   <body>\n
     $output
+    $webComponentBundleTag
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
   </body>
 </html>
@@ -319,6 +331,16 @@ START;
     }
 
     return $scripts;
+  }
+
+  /**
+   * Loads the Web Components bundle if one is configured for the workspace.
+   */
+  private function loadWebComponentBundle(): string
+  {
+    $scriptTag = WebComponentSupport::renderBundleTag(getcwd() ?: '.');
+
+    return $scriptTag ? $scriptTag . PHP_EOL : '';
   }
 
   /**

--- a/src/Rendering/Engines/ViewEngine.php
+++ b/src/Rendering/Engines/ViewEngine.php
@@ -9,6 +9,7 @@ use Assegai\Core\Exceptions\Http\NotFoundException;
 use Assegai\Core\Exceptions\RenderingException;
 use Assegai\Core\ModuleManager;
 use Assegai\Core\Rendering\View;
+use Assegai\Core\WebComponents\WebComponentSupport;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -119,6 +120,7 @@ START;
     echo PHP_EOL;
     echo $this->view->props->generateBodyScriptTags();
     echo $this->view->props->generateBodyScriptImportTags();
+    echo WebComponentSupport::renderBundleTag(getcwd() ?: '.');
 
     echo <<<END
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>

--- a/src/Util/Functions.php
+++ b/src/Util/Functions.php
@@ -13,6 +13,7 @@ use Assegai\Core\Injector;
 use Assegai\Core\Rendering\View;
 use Assegai\Core\Rendering\ViewProperties;
 use Assegai\Core\Util\Paths;
+use Assegai\Core\WebComponents\WebComponentSupport;
 use Westsworld\TimeAgo;
 
 if (!function_exists('env')) {
@@ -216,6 +217,36 @@ if (!function_exists('register_dependency')) {
   function register_dependency(string $entryId, mixed $token): int
   {
     return Injector::getInstance()->add($entryId, $token);
+  }
+}
+
+if (!function_exists('web_component_props')) {
+  /**
+   * Encodes component props for safe use inside a custom element attribute.
+   */
+  function web_component_props(mixed $props = []): string
+  {
+    return WebComponentSupport::encodeProps($props);
+  }
+}
+
+if (!function_exists('web_component_bundle_url')) {
+  /**
+   * Returns the resolved Web Components bundle URL if one is available.
+   */
+  function web_component_bundle_url(?string $workingDirectory = null): ?string
+  {
+    return WebComponentSupport::getBundleUrl($workingDirectory);
+  }
+}
+
+if (!function_exists('web_component_bundle_tag')) {
+  /**
+   * Returns the module script tag for the configured Web Components bundle.
+   */
+  function web_component_bundle_tag(?string $workingDirectory = null): string
+  {
+    return WebComponentSupport::renderBundleTag($workingDirectory);
   }
 }
 

--- a/src/WebComponents/WebComponentSupport.php
+++ b/src/WebComponents/WebComponentSupport.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Assegai\Core\WebComponents;
+
+use Assegai\Core\Util\Paths;
+
+/**
+ * Shared helpers for server-rendered Web Components.
+ */
+final class WebComponentSupport
+{
+    public const string DEFAULT_BUNDLE_URL = '/js/assegai-components.min.js';
+
+    private final function __construct()
+    {
+    }
+
+    /**
+     * Encodes component props for safe use inside an HTML attribute.
+     *
+     * @param mixed $props
+     * @return string
+     */
+    public static function encodeProps(mixed $props = []): string
+    {
+        $json = json_encode($props, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        if (false === $json) {
+            $json = '{}';
+        }
+
+        return htmlspecialchars($json, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+
+    /**
+     * Renders the module script tag for the configured Web Components bundle.
+     */
+    public static function renderBundleTag(?string $workingDirectory = null): string
+    {
+        $bundleUrl = self::getBundleUrl($workingDirectory);
+
+        if ($bundleUrl === null) {
+            return '';
+        }
+
+        $escapedUrl = htmlspecialchars($bundleUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+        return "<script type=\"module\" src=\"$escapedUrl\"></script>";
+    }
+
+    /**
+     * Resolves the configured Web Components bundle URL, if available.
+     */
+    public static function getBundleUrl(?string $workingDirectory = null): ?string
+    {
+        $workingDirectory ??= getcwd() ?: '.';
+        $config = self::loadConfig($workingDirectory);
+
+        if (($config['enabled'] ?? null) === false) {
+            return null;
+        }
+
+        $configuredBundleUrl = self::normalizeBundleUrl(
+            $config['bundleUrl'] ?? $config['bundlePath'] ?? $config['output'] ?? null
+        );
+
+        if ($configuredBundleUrl !== null) {
+            if (($config['enabled'] ?? null) === true || self::bundleExists($configuredBundleUrl, $workingDirectory)) {
+                return $configuredBundleUrl;
+            }
+
+            return null;
+        }
+
+        return self::bundleExists(self::DEFAULT_BUNDLE_URL, $workingDirectory)
+            ? self::DEFAULT_BUNDLE_URL
+            : null;
+    }
+
+    /**
+     * Loads the Web Components section from the workspace config if it exists.
+     *
+     * @return array<string, mixed>
+     */
+    private static function loadConfig(string $workingDirectory): array
+    {
+        $configFilename = Paths::join($workingDirectory, 'assegai.json');
+
+        if (!is_file($configFilename)) {
+            return [];
+        }
+
+        $contents = file_get_contents($configFilename);
+
+        if (!$contents || !json_is_valid($contents)) {
+            return [];
+        }
+
+        $config = json_decode($contents, true);
+
+        if (!is_array($config)) {
+            return [];
+        }
+
+        return is_array($config['webComponents'] ?? null)
+            ? $config['webComponents']
+            : [];
+    }
+
+    /**
+     * Normalizes a configured bundle path into a browser URL.
+     */
+    private static function normalizeBundleUrl(?string $bundlePath): ?string
+    {
+        if (!$bundlePath) {
+            return null;
+        }
+
+        if (filter_var($bundlePath, FILTER_VALIDATE_URL)) {
+            return $bundlePath;
+        }
+
+        $bundlePath = '/' . ltrim($bundlePath, '/');
+
+        if (str_starts_with($bundlePath, '/public/')) {
+            return substr($bundlePath, strlen('/public'));
+        }
+
+        return $bundlePath;
+    }
+
+    /**
+     * Checks whether the bundle exists locally for a given browser URL.
+     */
+    private static function bundleExists(string $bundleUrl, string $workingDirectory): bool
+    {
+        if (filter_var($bundleUrl, FILTER_VALIDATE_URL)) {
+            return true;
+        }
+
+        $bundleFilename = Paths::join($workingDirectory, 'public', ltrim($bundleUrl, '/'));
+
+        return is_file($bundleFilename);
+    }
+}

--- a/tests/Unit/WebComponentsCest.php
+++ b/tests/Unit/WebComponentsCest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Unit;
+
+use Assegai\Core\Rendering\Engines\DefaultTemplateEngine;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Tests\Support\UnitTester;
+
+class WebComponentsCest
+{
+  private string $workspace = '';
+  private string $originalWorkingDirectory = '';
+  private string $componentClass = '';
+
+  public function _before(UnitTester $I): void
+  {
+    $this->originalWorkingDirectory = getcwd() ?: '.';
+    $this->workspace = sys_get_temp_dir() . '/assegai-web-components-' . uniqid('', true);
+    $componentBasename = 'TestWebComponentPage' . str_replace('.', '', uniqid('', true));
+    $componentFilename = $componentBasename . '.php';
+    $templateFilename = $componentBasename . '.twig';
+    $this->componentClass = "Tests\\WebComponents\\$componentBasename";
+
+    mkdir($this->workspace . '/public/js', 0777, true);
+    mkdir($this->workspace . '/public/assets', 0777, true);
+    mkdir($this->workspace . '/src', 0777, true);
+
+    file_put_contents(
+      $this->workspace . '/assegai.json',
+      json_encode(['webComponents' => ['enabled' => true]], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+    );
+    file_put_contents($this->workspace . '/public/js/assegai-components.min.js', 'console.log("wc bundle");');
+    file_put_contents($this->workspace . '/public/assets/components.js', 'console.log("alt wc bundle");');
+    file_put_contents(
+      $this->workspace . '/src/' . $componentFilename,
+      <<<PHP
+<?php
+
+namespace Tests\WebComponents;
+
+use Assegai\Core\Attributes\Component;
+use Assegai\Core\Components\AssegaiComponent;
+
+#[Component(
+  selector: 'app-test-web-component-page',
+  templateUrl: '$templateFilename'
+)]
+class $componentBasename extends AssegaiComponent
+{
+  public string \$name = 'Ada';
+  public string \$quote = "Let's ship";
+}
+PHP
+    );
+    file_put_contents(
+      $this->workspace . '/src/' . $templateFilename,
+      <<<TWIG
+<app-user-card data-props='{{ ctx.webComponentProps({ name: name, quote: quote }) }}'>
+  <p>{{ name }}</p>
+</app-user-card>
+TWIG
+    );
+
+    require_once $this->workspace . '/src/' . $componentFilename;
+    chdir($this->workspace);
+  }
+
+  public function _after(UnitTester $I): void
+  {
+    chdir($this->originalWorkingDirectory);
+    $this->deleteDirectory($this->workspace);
+  }
+
+  public function testTheWebComponentPropsHelperEscapesJsonForHtmlAttributes(UnitTester $I): void
+  {
+    $encoded = web_component_props(['quote' => "Let's <ship>"]);
+
+    $I->assertSame('{&quot;quote&quot;:&quot;Let&#039;s &lt;ship&gt;&quot;}', $encoded);
+  }
+
+  public function testTheWebComponentBundleHelpersResolveTheConfiguredBundle(UnitTester $I): void
+  {
+    $I->assertSame('/js/assegai-components.min.js', web_component_bundle_url($this->workspace));
+    $I->assertSame(
+      '<script type="module" src="/js/assegai-components.min.js"></script>',
+      web_component_bundle_tag($this->workspace)
+    );
+
+    $this->writeWorkspaceConfig([
+      'webComponents' => [
+        'enabled' => true,
+        'bundlePath' => 'public/assets/components.js',
+      ],
+    ]);
+
+    $I->assertSame('/assets/components.js', web_component_bundle_url($this->workspace));
+  }
+
+  public function testTheWebComponentBundleHelpersCanBeDisabled(UnitTester $I): void
+  {
+    $this->writeWorkspaceConfig([
+      'webComponents' => [
+        'enabled' => false,
+      ],
+    ]);
+
+    $I->assertNull(web_component_bundle_url($this->workspace));
+    $I->assertSame('', web_component_bundle_tag($this->workspace));
+  }
+
+  public function testTheDefaultTemplateEngineInjectsTheBundleAndExposesTheTwigHelper(UnitTester $I): void
+  {
+    $componentClass = $this->componentClass;
+    $component = new $componentClass();
+    $engine = new DefaultTemplateEngine();
+
+    $html = $engine
+      ->setRootComponent($component)
+      ->render();
+
+    $I->assertStringContainsString(
+      "data-props='{&quot;name&quot;:&quot;Ada&quot;,&quot;quote&quot;:&quot;Let&#039;s ship&quot;}'",
+      $html
+    );
+    $I->assertStringContainsString(
+      '<script type="module" src="/js/assegai-components.min.js"></script>',
+      $html
+    );
+  }
+
+  /**
+   * @param array<string, mixed> $config
+   */
+  private function writeWorkspaceConfig(array $config): void
+  {
+    file_put_contents(
+      $this->workspace . '/assegai.json',
+      json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+    );
+  }
+
+  private function deleteDirectory(string $directory): void
+  {
+    if (!is_dir($directory)) {
+      return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+      new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS),
+      RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($iterator as $entry) {
+      if ($entry->isDir()) {
+        rmdir($entry->getPathname());
+        continue;
+      }
+
+      unlink($entry->getPathname());
+    }
+
+    rmdir($directory);
+  }
+}


### PR DESCRIPTION
This pull request significantly enhances Assegai's documentation and rendering engine to provide first-class support for server-rendered UI, HTMX, and Web Components. The changes clarify how to use these features together, introduce new helpers for working with Web Components in both PHP and Twig templates, and ensure that the Web Components bundle is automatically injected into rendered HTML when available. The documentation is updated to reflect these improvements and guide users through the new workflow.

**Documentation improvements:**

* Expanded the documentation in `docs/pages-and-components.md` to explain how Assegai supports classic server-rendered views, HTMX, and Web Components, including usage patterns, configuration, and CLI workflows. The documentation now includes practical examples and guidance on when to use each rendering style. [[1]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL3-R40) [[2]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL45-R89) [[3]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL73-R103) [[4]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL94-R124) [[5]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL116-R148) [[6]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL129-R159) [[7]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL139-R376)
* Updated the main documentation index to highlight the expanded focus on Pages, Components, HTMX, and Web Components, and clarified how these concepts shape rendered pages. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L30-R30) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L66-R66)
* Added a new section to the main `README.md` introducing server-rendered UI, HTMX, and Web Components, with a link to the detailed walkthrough.

**Rendering engine enhancements:**

* Added automatic injection of the Web Components bundle in both the `DefaultTemplateEngine` and `ViewEngine`, so that if a bundle is present, it is included as a module script tag in rendered HTML. [[1]](diffhunk://#diff-1c1e3a924c22227d4e8d802435f72f5c063e7cce2824d9826b28f0c2eb8e17a5R11) [[2]](diffhunk://#diff-1c1e3a924c22227d4e8d802435f72f5c063e7cce2824d9826b28f0c2eb8e17a5R28) [[3]](diffhunk://#diff-1c1e3a924c22227d4e8d802435f72f5c063e7cce2824d9826b28f0c2eb8e17a5R243) [[4]](diffhunk://#diff-1c1e3a924c22227d4e8d802435f72f5c063e7cce2824d9826b28f0c2eb8e17a5R257) [[5]](diffhunk://#diff-1c1e3a924c22227d4e8d802435f72f5c063e7cce2824d9826b28f0c2eb8e17a5R336-R345) [[6]](diffhunk://#diff-1519a734313b27d97b86fc685c8756823279338d2720de5f032632146de505e2R12) [[7]](diffhunk://#diff-1519a734313b27d97b86fc685c8756823279338d2720de5f032632146de505e2R123)
* Exposed new helpers (`web_component_props`, `web_component_bundle_url`, `web_component_bundle_tag`) for safely encoding props, retrieving the bundle URL, and rendering the module script tag, available in both PHP and Twig templates. [[1]](diffhunk://#diff-457b5588925dcc15f9989c42cf5441ac78b140be2189a35cd926457bcdc3ef02R16) [[2]](diffhunk://#diff-457b5588925dcc15f9989c42cf5441ac78b140be2189a35cd926457bcdc3ef02R223-R252) [[3]](diffhunk://#diff-1c1e3a924c22227d4e8d802435f72f5c063e7cce2824d9826b28f0c2eb8e17a5R189-R196)

These changes make Assegai's server-first UI stack more powerful and easier to use, enabling seamless integration of progressive enhancement techniques and modern Web Components.