### PR TITLE
Improve default storage path handling for empty values

### DIFF
--- a/src/Util/Definitions.php
+++ b/src/Util/Definitions.php
@@ -2,7 +2,13 @@
 
 namespace Assegai\Core\Util;
 
-defined('DEFAULT_STORAGE_PATH')     || define('DEFAULT_STORAGE_PATH',     trim(shell_exec('pwd')) . '/uploads');
+$defaultStorageRoot = \getcwd();
+
+if ($defaultStorageRoot === false || $defaultStorageRoot === '') {
+  $defaultStorageRoot = '.';
+}
+
+defined('DEFAULT_STORAGE_PATH')     || define('DEFAULT_STORAGE_PATH',     rtrim($defaultStorageRoot, '/\\') . '/uploads');
 defined('DEFAULT_FIELD_NAME_SIZE')  || define('DEFAULT_FIELD_NAME_SIZE',  100);
 defined('DEFAULT_FIELD_SIZE')       || define('DEFAULT_FIELD_SIZE',       '1MB');
 defined('DEFAULT_MAX_FILE_SIZE')    || define('DEFAULT_MAX_FILE_SIZE',    5000);


### PR DESCRIPTION
This pull request updates how the default storage path is determined in the `src/Util/Definitions.php` file. Instead of using `shell_exec('pwd')`, it now uses PHP's `getcwd()` function, with a fallback to the current directory if `getcwd()` fails. This change improves portability and reliability.

**Configuration improvements:**

* Changed the definition of `DEFAULT_STORAGE_PATH` to use `getcwd()` instead of `shell_exec('pwd')`, with a fallback to `'.'` if `getcwd()` fails, and ensured the path is properly trimmed.