### PR TITLE
Ensure application shutdown hooks are invoked after execution

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -624,9 +624,13 @@ class App implements AppInterface
      */
     public function run(): void
     {
-        $this->runtime->run($this, function (): void {
-            $this->runDefaultHttpLifecycle();
-        });
+        try {
+            $this->runtime->run($this, function (): void {
+                $this->runDefaultHttpLifecycle();
+            });
+        } finally {
+            $this->shutdown();
+        }
     }
 
     /**

--- a/tests/Unit/RuntimeCest.php
+++ b/tests/Unit/RuntimeCest.php
@@ -504,6 +504,55 @@ class RuntimeCest
     $I->assertSame(1, \Tests\Runtime\LifecycleCounters::$applicationShutdownCalls);
   }
 
+  public function testAppRunInvokesShutdownHooksForNonOpenSwooleRuntimes(UnitTester $I): void
+  {
+    $capturingEmitter = new class implements ResponseEmitterInterface {
+      public string $body = '';
+      public ?ResponseInterface $response = null;
+
+      public function emit(string $body, ?ResponseInterface $response = null): void
+      {
+        $this->body = $body;
+        $this->response = $response;
+      }
+    };
+
+    $runtime = new class implements HttpRuntimeInterface {
+      public function getName(): string
+      {
+        return 'test-runtime';
+      }
+
+      public function run(AppInterface $app, callable $handler): void
+      {
+        $handler();
+      }
+    };
+
+    $app = AssegaiFactory::create(\Tests\Runtime\LifecycleAwareAppModule::class, $runtime);
+    $app->setRuntimeRequestContext(new RuntimeRequestContext(
+      server: [
+        'REQUEST_METHOD' => 'GET',
+        'REQUEST_URI' => '/lifecycle-probe',
+        'QUERY_STRING' => '',
+        'HTTP_HOST' => 'runtime.local',
+        'REQUEST_SCHEME' => 'http',
+      ],
+      query: [
+        'path' => '/lifecycle-probe',
+      ],
+    ));
+    $app->setRuntimeResponseEmitter($capturingEmitter);
+
+    $app->run();
+
+    $I->assertSame(1, \Tests\Runtime\LifecycleCounters::$moduleInitCalls);
+    $I->assertSame(1, \Tests\Runtime\LifecycleCounters::$applicationBootstrapCalls);
+    $I->assertSame(1, \Tests\Runtime\LifecycleCounters::$applicationShutdownCalls);
+    $I->assertSame(200, $capturingEmitter->response?->getStatusCode());
+    $I->assertSame(['ok' => true], json_decode($capturingEmitter->body, true));
+  }
+
   public function testOpenSwooleRuntimeCanHandleAFullWorkerLifecycle(UnitTester $I): void
   {
     $request = new class {


### PR DESCRIPTION
This pull request ensures that application shutdown hooks are always invoked after the application runs, regardless of the runtime in use. It also adds a new unit test to verify this behavior for non-OpenSwoole runtimes.

**Lifecycle management improvements:**

* Modified the `run()` method in `App.php` to always call `shutdown()` after the runtime finishes, ensuring shutdown hooks are executed for all runtimes.

**Testing enhancements:**

* Added a new unit test `testAppRunInvokesShutdownHooksForNonOpenSwooleRuntimes` in `RuntimeCest.php` to verify that shutdown hooks are properly invoked and the response is as expected for non-OpenSwoole runtimes.