### PR TITLE
Harden core asset and view handling

### DIFF
--- a/docs/building-a-feature.md
+++ b/docs/building-a-feature.md
@@ -201,7 +201,7 @@ class PostEntity
 }
 ```
 
-The `database` name should match the connection configured in `config/default.php`.
+The `database` name should match the connection configured in `config/secure.php`.
 
 If you want the whole feature to share the same default connection, you can also put it on the module:
 

--- a/docs/frontend-with-web-components.md
+++ b/docs/frontend-with-web-components.md
@@ -160,7 +160,7 @@ Built-in `ctx` helpers include:
 - `ctx.timeAgo(...)`
 - `ctx.env(...)`
 - `ctx.getLang()`
-- `ctx.webComponentProps(...)` and `ctx.wcProps(...)`
+- `ctx.wcProps(...)`
 - `ctx.webComponentBundleUrl()`
 
 ## A generated component is expected to render through the shadow root
@@ -218,7 +218,7 @@ For most new projects, `serve --dev` is the easiest starting point.
 From Twig:
 
 ```twig
-<app-user-card data-props='{{ ctx.webComponentProps({
+<app-user-card data-props='{{ ctx.wcProps({
   name: user.name,
   role: user.role
 }) }}'></app-user-card>
@@ -228,7 +228,7 @@ From a PHP view:
 
 ```php
 <app-user-card
-  data-props='<?= web_component_props([
+  data-props='<?= wc_props([
     "name" => $user["name"],
     "role" => $user["role"],
   ]) ?>'
@@ -237,7 +237,7 @@ From a PHP view:
 
 `data-props` is not a special Assegai-only format. It is just JSON stored in an HTML attribute.
 
-The helper exists because JSON inside HTML needs to be encoded and escaped safely. Quotes, apostrophes, and other characters can break the markup if you try to hand-build the string. `web_component_props(...)` and `ctx.webComponentProps(...)` do that safely and give PHP views and Twig templates one consistent way to pass data.
+The helper exists because JSON inside HTML needs to be encoded and escaped safely. Quotes, apostrophes, and other characters can break the markup if you try to hand-build the string. `wc_props(...)` and `ctx.wcProps(...)` do that safely and give PHP views and Twig templates one consistent way to pass data.
 
 The runtime reads that `data-props` payload and hydrates the custom element in the browser.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,10 +48,12 @@ The scaffold flow currently prompts for:
 
 If you opt into database setup during scaffolding, the CLI also:
 
-- writes database settings into `config/default.php`
+- writes database settings into `config/secure.php`
 - generates a default users resource when one does not already exist
 - updates `src/AppModule.php` to import that resource module
 - attempts to install `assegaiphp/orm`
+
+In a fresh project, `config/secure.php` sits at the top of the config cascade and overrides the lower-priority config files when it is present.
 
 ## What a fresh project looks like
 
@@ -64,7 +66,8 @@ blog-api/
 ├── bootstrap.php
 ├── composer.json
 ├── config/
-│   └── default.php
+│   ├── default.php
+│   └── secure.php
 ├── index.php
 ├── public/
 │   ├── css/style.css

--- a/docs/pages-and-components.md
+++ b/docs/pages-and-components.md
@@ -256,7 +256,7 @@ Assegai keeps the Twig environment fairly small on purpose. The built-in helpers
 - `ctx.timeAgo(timestamp, timezone = null)` for relative time output
 - `ctx.env(key, default = null)` for environment values
 - `ctx.getLang()` for the current language
-- `ctx.webComponentProps(...)` or `ctx.wcProps(...)` for safe Web Component props
+- `ctx.wcProps(...)` for safe Web Component props
 - `ctx.webComponentBundleUrl()` for the bundle URL
 
 Example:
@@ -331,7 +331,7 @@ Assegai's Web Components support is built around a server-first model:
 ### Twig templates get a safe props helper
 
 ```twig
-<app-user-card data-props='{{ ctx.webComponentProps({
+<app-user-card data-props='{{ ctx.wcProps({
   name: name,
   quote: quote
 }) }}'>
@@ -341,13 +341,13 @@ Assegai's Web Components support is built around a server-first model:
 
 That helper is doing one practical job: turning your PHP or Twig data into JSON that is safe to place inside an HTML attribute.
 
-Without that step, quotes and special characters can break the markup. So although the browser ultimately receives a JSON string, `ctx.webComponentProps(...)` keeps the template code safe and predictable.
+Without that step, quotes and special characters can break the markup. So although the browser ultimately receives a JSON string, `ctx.wcProps(...)` keeps the template code safe and predictable.
 
 ### PHP views can use the same pattern
 
 ```php
 <app-user-card
-  data-props='<?= web_component_props([
+  data-props='<?= wc_props([
     "name" => $name,
     "quote" => $quote,
   ]) ?>'
@@ -417,7 +417,7 @@ Use `enabled: false` to disable automatic injection entirely.
 Assegai exposes small helpers around bundle resolution and prop encoding:
 
 ```php
-web_component_props($props);
+wc_props($props);
 web_component_bundle_url();
 web_component_bundle_tag();
 ```
@@ -425,7 +425,7 @@ web_component_bundle_tag();
 Inside Twig component templates, these are surfaced through `ctx`:
 
 ```twig
-{{ ctx.webComponentProps({ name: name }) }}
+{{ ctx.wcProps({ name: name }) }}
 {{ ctx.webComponentBundleUrl() }}
 ```
 

--- a/src/App.php
+++ b/src/App.php
@@ -731,7 +731,7 @@ class App implements AppInterface
             return false;
         }
 
-        if ($this->shouldBypassPublicResourceStreaming($resourcePath)) {
+        if ($this->shouldBypassPublicResourceStreaming($resourcePath, $relativePath)) {
             return false;
         }
 
@@ -746,8 +746,8 @@ class App implements AppInterface
     {
         $segments = array_filter(explode('/', $relativePath), static fn(string $segment): bool => $segment !== '');
 
-        foreach ($segments as $segment) {
-            if (str_starts_with($segment, '.')) {
+        foreach ($segments as $index => $segment) {
+            if (str_starts_with($segment, '.') && !($index === 0 && $segment === '.well-known')) {
                 return true;
             }
         }
@@ -759,11 +759,73 @@ class App implements AppInterface
      * @param string $resourcePath
      * @return bool
      */
-    protected function shouldBypassPublicResourceStreaming(string $resourcePath): bool
+    protected function shouldBypassPublicResourceStreaming(string $resourcePath, string $relativePath): bool
     {
         $extension = strtolower(pathinfo($resourcePath, PATHINFO_EXTENSION));
+        $normalizedRelativePath = trim(str_replace('\\', '/', $relativePath), '/');
 
         if (in_array($extension, ['php', 'phtml', 'phar', 'inc'], true)) {
+            return true;
+        }
+
+        if ($extension === '') {
+            return !str_starts_with($normalizedRelativePath, '.well-known/');
+        }
+
+        $allowedExtensions = [
+            '7z',
+            'atom',
+            'avif',
+            'bmp',
+            'bz2',
+            'css',
+            'csv',
+            'eot',
+            'gif',
+            'gz',
+            'htm',
+            'html',
+            'ico',
+            'jpeg',
+            'jpg',
+            'js',
+            'json',
+            'map',
+            'md',
+            'mjs',
+            'mp3',
+            'mp4',
+            'mpeg',
+            'oga',
+            'ogv',
+            'ogx',
+            'otf',
+            'pdf',
+            'png',
+            'rss',
+            'rtf',
+            'svg',
+            'svgz',
+            'tgz',
+            'ts',
+            'ttf',
+            'txt',
+            'wasm',
+            'wav',
+            'weba',
+            'webm',
+            'webmanifest',
+            'webp',
+            'woff',
+            'woff2',
+            'xhtml',
+            'xls',
+            'xlsx',
+            'xml',
+            'zip',
+        ];
+
+        if (!in_array($extension, $allowedExtensions, true)) {
             return true;
         }
 

--- a/src/Rendering/Engines/DefaultTemplateEngine.php
+++ b/src/Rendering/Engines/DefaultTemplateEngine.php
@@ -191,7 +191,7 @@ class DefaultTemplateEngine extends TemplateEngine
             $ctx->addMethod('getLang', fn() => Request::current()->getLang());
         }
 
-        $webComponentPropsMethod = fn(mixed $props = []) => new Markup(web_component_props($props), 'UTF-8');
+        $webComponentPropsMethod = fn(mixed $props = []) => new Markup(wc_props($props), 'UTF-8');
 
         if (!method_exists($ctx, 'webComponentProps')) {
             $ctx->addMethod('webComponentProps', $webComponentPropsMethod);

--- a/src/Rendering/View.php
+++ b/src/Rendering/View.php
@@ -55,8 +55,9 @@ class View
     public ?string $component = null
   )
   {
-    $templatePath = Paths::join(Paths::getViewDirectory(), $templateUrl . '.php');
     try {
+      $templatePath = $this->resolveViewTemplatePath($templateUrl);
+
       if ($this->component) {
         $componentReflection = new ReflectionClass($this->component);
         $componentAttrReflections = $componentReflection->getAttributes(Component::class);
@@ -67,8 +68,7 @@ class View
 
         foreach ($componentAttrReflections as $componentAttrReflection) {
           $this->componentAttribute = $componentAttrReflection->newInstance();
-          $componentPath = dirname($componentReflection->getFileName());
-          $templatePath = Paths::join($componentPath, $this->componentAttribute->templateUrl);
+          $templatePath = $this->resolveComponentTemplatePath($componentReflection, $this->componentAttribute);
         }
 
         $data = get_object_vars($this->getComponent());
@@ -79,13 +79,74 @@ class View
       $this->templateUrl = $templatePath;
       $this->data = $data;
       $this->props = is_array($props) ? ViewProperties::fromArray($props) : $props;
-
-      if (! file_exists($this->templateUrl) ) {
-        throw new RenderingException(message: 'Failed to open file at ' . $this->templateUrl);
-      }
     } catch (ReflectionException $exception) {
       throw new HttpException($exception->getMessage());
     }
+  }
+
+  /**
+   * @throws RenderingException
+   */
+  private function resolveViewTemplatePath(string $templateUrl): string
+  {
+    $viewDirectory = realpath(Paths::getViewDirectory());
+
+    if (!is_string($viewDirectory) || !is_dir($viewDirectory)) {
+      throw new RenderingException(message: 'Failed to resolve the views directory.');
+    }
+
+    return $this->resolveTemplatePathWithinDirectory(
+      $viewDirectory,
+      Paths::join($viewDirectory, $templateUrl . '.php'),
+    );
+  }
+
+  /**
+   * @throws RenderingException
+   */
+  private function resolveComponentTemplatePath(ReflectionClass $componentReflection, Component $componentAttribute): string
+  {
+    $componentFilename = $componentReflection->getFileName();
+
+    if (!is_string($componentFilename) || $componentFilename === '') {
+      throw new RenderingException(message: 'Failed to resolve the component path.');
+    }
+
+    $componentDirectory = realpath(dirname($componentFilename));
+
+    if (!is_string($componentDirectory) || !is_dir($componentDirectory)) {
+      throw new RenderingException(message: 'Failed to resolve the component directory.');
+    }
+
+    return $this->resolveTemplatePathWithinDirectory(
+      $componentDirectory,
+      Paths::join($componentDirectory, (string) $componentAttribute->templateUrl),
+    );
+  }
+
+  /**
+   * @throws RenderingException
+   */
+  private function resolveTemplatePathWithinDirectory(string $baseDirectory, string $candidatePath): string
+  {
+    $resolvedPath = realpath($candidatePath);
+
+    if (!is_string($resolvedPath) || !is_file($resolvedPath)) {
+      throw new RenderingException(message: 'Failed to open file at ' . $candidatePath);
+    }
+
+    if (!$this->isPathInsideDirectory($resolvedPath, $baseDirectory)) {
+      throw new RenderingException(message: 'Template path must stay within ' . $baseDirectory);
+    }
+
+    return $resolvedPath;
+  }
+
+  private function isPathInsideDirectory(string $path, string $directory): bool
+  {
+    $directory = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+    return str_starts_with($path, $directory);
   }
 
   /**

--- a/src/Util/Functions.php
+++ b/src/Util/Functions.php
@@ -220,13 +220,23 @@ if (!function_exists('register_dependency')) {
   }
 }
 
+if (!function_exists('wc_props')) {
+  /**
+   * Encodes component props for safe use inside a custom element attribute.
+   */
+  function wc_props(mixed $props = []): string
+  {
+    return WebComponentSupport::encodeProps($props);
+  }
+}
+
 if (!function_exists('web_component_props')) {
   /**
    * Encodes component props for safe use inside a custom element attribute.
    */
   function web_component_props(mixed $props = []): string
   {
-    return WebComponentSupport::encodeProps($props);
+    return wc_props($props);
   }
 }
 

--- a/tests/Unit/RuntimeCest.php
+++ b/tests/Unit/RuntimeCest.php
@@ -1340,7 +1340,7 @@ class RuntimeCest
     $I->assertNull(RuntimeContext::get(Responder::class));
   }
 
-  public function testPublicResourceResolutionRejectsTraversalHiddenFilesAndPhpScripts(UnitTester $I): void
+  public function testPublicResourceResolutionRejectsTraversalHiddenFilesAndUnsafeScriptLikeAssets(UnitTester $I): void
   {
     $publicDirectory = $this->workingDirectory . '/public';
 
@@ -1351,10 +1351,19 @@ class RuntimeCest
     $safeAsset = $publicDirectory . '/logo.png';
     $hiddenAsset = $publicDirectory . '/.private.txt';
     $scriptAsset = $publicDirectory . '/debug.php';
+    $sourceAsset = $publicDirectory . '/debug.phps';
+    $wellKnownDirectory = $publicDirectory . '/.well-known/acme-challenge';
+    $wellKnownAsset = $wellKnownDirectory . '/token';
+
+    if (!is_dir($wellKnownDirectory)) {
+      @mkdir($wellKnownDirectory, 0777, true);
+    }
 
     file_put_contents($safeAsset, 'png-bytes');
     file_put_contents($hiddenAsset, 'hidden');
     file_put_contents($scriptAsset, "<?php echo 'leak';");
+    file_put_contents($sourceAsset, '<?php echo "source";');
+    file_put_contents($wellKnownAsset, 'acme-token');
 
     $app = AssegaiFactory::createFromProject('Tests\\Runtime\\DummyAppModule', $this->workingDirectory);
     $resolvePublicResourcePath = new \ReflectionMethod($app, 'resolvePublicResourcePath');
@@ -1363,16 +1372,26 @@ class RuntimeCest
       $resolvedSafeAsset = $resolvePublicResourcePath->invoke($app, '/logo.png');
       $resolvedHiddenAsset = $resolvePublicResourcePath->invoke($app, '/.private.txt');
       $resolvedScriptAsset = $resolvePublicResourcePath->invoke($app, '/debug.php');
+      $resolvedSourceAsset = $resolvePublicResourcePath->invoke($app, '/debug.phps');
+      $resolvedWellKnownAsset = $resolvePublicResourcePath->invoke($app, '/.well-known/acme-challenge/token');
       $resolvedTraversal = $resolvePublicResourcePath->invoke($app, '/../bootstrap.php');
 
       $I->assertSame(realpath($safeAsset), $resolvedSafeAsset);
       $I->assertFalse($resolvedHiddenAsset);
       $I->assertFalse($resolvedScriptAsset);
+      $I->assertFalse($resolvedSourceAsset);
+      $I->assertSame(realpath($wellKnownAsset), $resolvedWellKnownAsset);
       $I->assertFalse($resolvedTraversal);
     } finally {
-      foreach ([$safeAsset, $hiddenAsset, $scriptAsset] as $filename) {
+      foreach ([$safeAsset, $hiddenAsset, $scriptAsset, $sourceAsset, $wellKnownAsset] as $filename) {
         if (is_file($filename)) {
           unlink($filename);
+        }
+      }
+
+      foreach ([$wellKnownDirectory, dirname($wellKnownDirectory)] as $directory) {
+        if (is_dir($directory)) {
+          @rmdir($directory);
         }
       }
     }

--- a/tests/Unit/ViewEngineCest.php
+++ b/tests/Unit/ViewEngineCest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Assegai\Core\Exceptions\RenderingException;
 use Assegai\Core\Rendering\Engines\ViewEngine;
 use Assegai\Core\Rendering\View;
 use Assegai\Core\Rendering\ViewProperties;
@@ -14,6 +15,7 @@ class ViewEngineCest
   private string $previousWorkingDirectory = '';
   private string $viewsDirectory = '';
   private string $viewFilename = '';
+  private string $siblingTemplateFilename = '';
 
   public function _before(): void
   {
@@ -22,12 +24,14 @@ class ViewEngineCest
 
     $this->viewsDirectory = getcwd() . '/src/Views';
     $this->viewFilename = $this->viewsDirectory . '/render-test.php';
+    $this->siblingTemplateFilename = getcwd() . '/src/secret.php';
 
     if (!is_dir($this->viewsDirectory)) {
       mkdir($this->viewsDirectory, 0777, true);
     }
 
     file_put_contents($this->viewFilename, '<main><?= $message ?></main>');
+    file_put_contents($this->siblingTemplateFilename, '<?php echo "secret";');
     $this->resetSingleton(ViewEngine::class);
   }
 
@@ -35,6 +39,10 @@ class ViewEngineCest
   {
     if (is_file($this->viewFilename)) {
       unlink($this->viewFilename);
+    }
+
+    if (is_file($this->siblingTemplateFilename)) {
+      unlink($this->siblingTemplateFilename);
     }
 
     if (is_dir($this->viewsDirectory)) {
@@ -60,6 +68,14 @@ class ViewEngineCest
     $I->assertStringContainsString('<title>Render Test</title>', $html);
     $I->assertStringContainsString('<main>Rendered output</main>', $html);
     $I->assertStringContainsString('<!DOCTYPE html>', $html);
+  }
+
+  public function testViewRejectsTraversalOutsideViewsDirectory(UnitTester $I): void
+  {
+    $I->expectThrowable(
+      RenderingException::class,
+      static fn(): View => new View('../secret'),
+    );
   }
 
   /**

--- a/tests/Unit/WebComponentsCest.php
+++ b/tests/Unit/WebComponentsCest.php
@@ -99,11 +99,12 @@ TWIG
     $this->deleteDirectory($this->workspace);
   }
 
-  public function testTheWebComponentPropsHelperEscapesJsonForHtmlAttributes(UnitTester $I): void
+  public function testTheWcPropsHelperEscapesJsonForHtmlAttributes(UnitTester $I): void
   {
-    $encoded = web_component_props(['quote' => "Let's <ship>"]);
+    $encoded = wc_props(['quote' => "Let's <ship>"]);
 
     $I->assertSame('{&quot;quote&quot;:&quot;Let&#039;s &lt;ship&gt;&quot;}', $encoded);
+    $I->assertSame($encoded, web_component_props(['quote' => "Let's <ship>"]));
   }
 
   public function testTheWebComponentBundleHelpersResolveTheConfiguredBundle(UnitTester $I): void


### PR DESCRIPTION
This pull request introduces several improvements and security enhancements to the handling of public resource resolution, view template path resolution, and documentation consistency for web component helpers. The most significant changes include tightening which files can be served from the public directory, making template path resolution more robust and secure, and standardizing the usage of the `wc_props` helper for web components across documentation and code.

**Security and public resource resolution:**

* Strengthened the logic in `App.php` to restrict which file types can be served from the public directory, only allowing a specific whitelist of extensions and special handling for `.well-known` directories; files like `.phps` and hidden files (except `.well-known`) are now explicitly blocked. (`src/App.php`) [[1]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fL734-R734) [[2]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fL749-R750) [[3]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fL762-R831)
* Updated and expanded the related unit tests to cover new edge cases, including `.phps` files and `.well-known` directory exceptions. (`tests/Unit/RuntimeCest.php`) [[1]](diffhunk://#diff-606a0a974e2da9bf0554b5f9c86c6570b838857bd13f9816dc9e158a50f9f838L1343-R1343) [[2]](diffhunk://#diff-606a0a974e2da9bf0554b5f9c86c6570b838857bd13f9816dc9e158a50f9f838R1354-R1366) [[3]](diffhunk://#diff-606a0a974e2da9bf0554b5f9c86c6570b838857bd13f9816dc9e158a50f9f838R1375-R1396)

**View template resolution and security:**

* Refactored `View.php` to resolve template paths using dedicated methods that ensure the template is within the expected directory, preventing directory traversal and accidental access to files outside the views/components directory. (`src/Rendering/View.php`) [[1]](diffhunk://#diff-8f3335b20f4559c5c737954b506ccd321809618907431a8d4d7bad7ded025fdbL58-R60) [[2]](diffhunk://#diff-8f3335b20f4559c5c737954b506ccd321809618907431a8d4d7bad7ded025fdbL70-R71) [[3]](diffhunk://#diff-8f3335b20f4559c5c737954b506ccd321809618907431a8d4d7bad7ded025fdbL82-R151)
* Added a new test to ensure sibling files outside the view directory cannot be loaded as templates, improving defense against path traversal. (`tests/Unit/ViewEngineCest.php`) [[1]](diffhunk://#diff-66c2b5321c31067ecc63d7767c8c4c134b99cde69a134eeec537cef52ef50583R5) [[2]](diffhunk://#diff-66c2b5321c31067ecc63d7767c8c4c134b99cde69a134eeec537cef52ef50583R18) [[3]](diffhunk://#diff-66c2b5321c31067ecc63d7767c8c4c134b99cde69a134eeec537cef52ef50583R27-R34) [[4]](diffhunk://#diff-66c2b5321c31067ecc63d7767c8c4c134b99cde69a134eeec537cef52ef50583R44-R47)

**Web component helpers and documentation consistency:**

* Standardized on the `wc_props` helper for encoding web component props, updating all documentation and code references from `web_component_props` and `ctx.webComponentProps` to `wc_props` and `ctx.wcProps` respectively. (`src/Rendering/Engines/DefaultTemplateEngine.php`, `src/Util/Functions.php`, `docs/frontend-with-web-components.md`, `docs/pages-and-components.md`) [[1]](diffhunk://#diff-1c1e3a924c22227d4e8d802435f72f5c063e7cce2824d9826b28f0c2eb8e17a5L194-R194) [[2]](diffhunk://#diff-457b5588925dcc15f9989c42cf5441ac78b140be2189a35cd926457bcdc3ef02R223-R239) [[3]](diffhunk://#diff-022fff6f1c705738fade2601d841933ed41f077eb79eb0abec1dcc5a89c60ed9L163-R163) [[4]](diffhunk://#diff-022fff6f1c705738fade2601d841933ed41f077eb79eb0abec1dcc5a89c60ed9L221-R221) [[5]](diffhunk://#diff-022fff6f1c705738fade2601d841933ed41f077eb79eb0abec1dcc5a89c60ed9L231-R231) [[6]](diffhunk://#diff-022fff6f1c705738fade2601d841933ed41f077eb79eb0abec1dcc5a89c60ed9L240-R240) [[7]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL259-R259) [[8]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL334-R334) [[9]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL344-R350) [[10]](diffhunk://#diff-7fbc93eb6373dfd8460953df8b0844f8bad932e2843ea024621c608c7864dd7aL420-R428)

**Configuration documentation improvements:**

* Updated documentation to clarify that database settings are now written to and read from `config/secure.php` instead of `config/default.php`, and explained the precedence of `secure.php` in the config cascade. (`docs/building-a-feature.md`, `docs/getting-started.md`) [[1]](diffhunk://#diff-84037ddcf7967d53e27e07a0d241ca746a1cc0700f53abaf0cf6cc4db084cfd3L204-R204) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L51-R57) [[3]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L67-R70)