### PR TITLE
Fix broken public asset references in core

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2026,11 +2026,6 @@ parameters:
 			path: src/Util/Validator.php
 
 		-
-			message: "#^Offset 'enabled' on array\\<string, mixed\\> on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: src/WebComponents/WebComponentSupport.php
-
-		-
 			message: "#^Offset 'interval' on array\\{bundleUrl\\: string, interval\\: int, markerUrl\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: src/WebComponents/WebComponentSupport.php

--- a/src/Util/Paths.php
+++ b/src/Util/Paths.php
@@ -136,7 +136,7 @@ final class Paths
       'txt' => 'text/plain',
       'wav' => 'audio/wav',
       'weba', 'webm' => 'audio/webm',
-      'webp' => 'audio/webp',
+      'webp' => 'image/webp',
       'woff' => 'font/woff',
       'woff2' => 'font/woff2',
       'xhtml' => 'application/xhtml+xml',

--- a/src/WebComponents/WebComponentSupport.php
+++ b/src/WebComponents/WebComponentSupport.php
@@ -80,7 +80,7 @@ final class WebComponentSupport
         );
 
         if ($configuredBundleUrl !== null) {
-            if (($config['enabled'] ?? null) === true || self::bundleExists($configuredBundleUrl, $workingDirectory)) {
+            if (filter_var($configuredBundleUrl, FILTER_VALIDATE_URL) || self::bundleExists($configuredBundleUrl, $workingDirectory)) {
                 return $configuredBundleUrl;
             }
 

--- a/tests/Unit/PathsCest.php
+++ b/tests/Unit/PathsCest.php
@@ -20,4 +20,37 @@ class PathsCest
       Paths::getPublicPath('/.assegai/wc-hot-reload.json?t=1742078500')
     );
   }
+
+  public function testTheMimeTypeResolverUsesBrowserSafeTypesForCommonAssets(UnitTester $I): void
+  {
+    $directory = sys_get_temp_dir() . '/assegai-paths-' . uniqid('', true);
+
+    if (!mkdir($directory, 0777, true) && !is_dir($directory)) {
+      $I->fail("Failed to create temporary directory: $directory");
+    }
+
+    $css = $directory . '/style.css';
+    $js = $directory . '/main.js';
+    $webp = $directory . '/logo.webp';
+
+    try {
+      file_put_contents($css, 'body {}');
+      file_put_contents($js, '');
+      file_put_contents($webp, 'webp-bytes');
+
+      $I->assertSame('text/css', Paths::getMimeType($css));
+      $I->assertSame('text/javascript', Paths::getMimeType($js));
+      $I->assertSame('image/webp', Paths::getMimeType($webp));
+    } finally {
+      foreach ([$css, $js, $webp] as $filename) {
+        if (is_file($filename)) {
+          unlink($filename);
+        }
+      }
+
+      if (is_dir($directory)) {
+        rmdir($directory);
+      }
+    }
+  }
 }

--- a/tests/Unit/WebComponentsCest.php
+++ b/tests/Unit/WebComponentsCest.php
@@ -137,6 +137,21 @@ TWIG
     $I->assertSame('', web_component_bundle_tag($this->workspace));
   }
 
+  public function testTheWebComponentBundleHelpersSkipMissingLocalBundles(UnitTester $I): void
+  {
+    unlink($this->workspace . '/public/js/assegai-components.min.js');
+
+    $this->writeWorkspaceConfig([
+      'webComponents' => [
+        'enabled' => true,
+        'output' => 'public/js/assegai-components.min.js',
+      ],
+    ]);
+
+    $I->assertNull(web_component_bundle_url($this->workspace));
+    $I->assertSame('', web_component_bundle_tag($this->workspace));
+  }
+
   public function testTheWebComponentRuntimeTagsInjectHotReloadWhenWatchIsActive(UnitTester $I): void
   {
     $this->writeWorkspaceConfig([


### PR DESCRIPTION
This pull request includes improvements to MIME type detection, more robust handling of web component bundle URLs, and expanded test coverage to ensure correct behavior. The most significant changes are a fix for the `webp` MIME type, a logic update for validating bundle URLs, and the addition of new unit tests for these behaviors.

**MIME type handling improvements:**

* Fixed the MIME type for `webp` files in `Paths::getMimeType` from `'audio/webp'` to the correct `'image/webp'`.
* Added a unit test `testTheMimeTypeResolverUsesBrowserSafeTypesForCommonAssets` to verify that common asset types (CSS, JS, WEBP) are resolved to browser-safe MIME types.

**Web component bundle URL validation:**

* Updated the logic in `WebComponentSupport::getBundleUrl` to use `filter_var` for URL validation instead of checking the `enabled` config key, ensuring only valid URLs or existing bundles are returned.
* Added a unit test `testTheWebComponentBundleHelpersSkipMissingLocalBundles` to verify that missing local bundles are correctly skipped and do not return a URL or tag.

**Static analysis configuration:**

* Removed a no-longer-applicable PHPStan baseline entry related to the `enabled` key in the web component support configuration, reflecting the updated code logic.