### PR TITLE
Add logging for handled exceptions in HTTP and Whoops handlers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1351,51 +1351,6 @@ parameters:
 			path: src/Rendering/Engines/DefaultTemplateEngine.php
 
 		-
-			message: "#^Call to function is_string\\(\\) with array\\{\\} will always evaluate to false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141 and 'config' will always evaluate to false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141 and 'env' will always evaluate to false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141 and 'getLang' will always evaluate to false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141 and 'timeAgo' will always evaluate to false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141 and 'translate' will always evaluate to false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141 and 'wcProps' will always evaluate to false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141 and 'webComponentBundleU…' will always evaluate to false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141 and 'webComponentProps' will always evaluate to false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
 			message: "#^Cannot access property \\$meta on Assegai\\\\Core\\\\Attributes\\\\Component\\|null\\.$#"
 			count: 1
 			path: src/Rendering/Engines/DefaultTemplateEngine.php
@@ -1411,11 +1366,6 @@ parameters:
 			path: src/Rendering/Engines/DefaultTemplateEngine.php
 
 		-
-			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
 			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
 			count: 1
 			path: src/Rendering/Engines/DefaultTemplateEngine.php
@@ -1427,26 +1377,6 @@ parameters:
 
 		-
 			message: "#^Method Assegai\\\\Core\\\\Rendering\\\\Engines\\\\DefaultTemplateEngine\\:\\:getGlobalStyles\\(\\) should return string\\|false but returns string\\|null\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Method class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141\\:\\:__call\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Method class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141\\:\\:__call\\(\\) has parameter \\$arguments with no type specified\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Method class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141\\:\\:__call\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Method class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:96\\:\\:load\\(\\) has parameter \\$class with no type specified\\.$#"
 			count: 1
 			path: src/Rendering/Engines/DefaultTemplateEngine.php
 
@@ -1477,56 +1407,6 @@ parameters:
 
 		-
 			message: "#^Property Assegai\\\\Core\\\\Rendering\\\\Engines\\\\DefaultTemplateEngine\\:\\:\\$componentFilename \\(string\\) does not accept string\\|false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Property class@anonymous/Rendering/Engines/DefaultTemplateEngine\\.php\\:141\\:\\:\\$methods type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Variable \\$author on left side of \\?\\? is never defined\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Variable \\$description on left side of \\?\\? is never defined\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Variable \\$htmxLink on left side of \\?\\?\\= is never defined\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Variable \\$keywords on left side of \\?\\? is never defined\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Variable \\$lang on left side of \\?\\?\\= is never defined\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Variable \\$props on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 2
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Variable \\$props on left side of \\?\\?\\= is never defined\\.$#"
-			count: 1
-			path: src/Rendering/Engines/DefaultTemplateEngine.php
-
-		-
-			message: "#^Variable \\$title on left side of \\?\\? is never defined\\.$#"
 			count: 1
 			path: src/Rendering/Engines/DefaultTemplateEngine.php
 

--- a/src/Exceptions/Handlers/Concerns/LogsHandledExceptions.php
+++ b/src/Exceptions/Handlers/Concerns/LogsHandledExceptions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Assegai\Core\Exceptions\Handlers\Concerns;
+
+use Assegai\Core\Exceptions\Http\HttpException;
+use Throwable;
+
+trait LogsHandledExceptions
+{
+  protected function logHandledException(Throwable $exception): void
+  {
+    if ($exception instanceof HttpException && $exception->getStatus()->code < 500) {
+      $this->logger->debug($exception->getMessage());
+      return;
+    }
+
+    $this->logger->error($exception->getMessage());
+
+    if ($exception instanceof HttpException) {
+      error_log($exception->getMessage() . ' in ' . $exception->getFile() . ' on line ' . $exception->getLine() . PHP_EOL . $exception->getTraceAsString() . PHP_EOL . PHP_EOL, 0);
+    }
+  }
+}

--- a/src/Exceptions/Handlers/HttpExceptionHandler.php
+++ b/src/Exceptions/Handlers/HttpExceptionHandler.php
@@ -6,6 +6,7 @@ use Assegai\Core\Config;
 use Assegai\Core\Enumerations\EnvironmentType;
 use Assegai\Core\Enumerations\Http\ContentType;
 use Assegai\Core\Exceptions\Handlers\Concerns\EmitsErrorResponses;
+use Assegai\Core\Exceptions\Handlers\Concerns\LogsHandledExceptions;
 use Assegai\Core\Exceptions\Handlers\Support\FrameworkErrorPageRenderer;
 use Assegai\Core\Exceptions\Http\HttpException;
 use Assegai\Core\Exceptions\Interfaces\ExceptionHandlerInterface;
@@ -23,6 +24,7 @@ use Throwable;
 class HttpExceptionHandler implements ExceptionHandlerInterface
 {
   use EmitsErrorResponses;
+  use LogsHandledExceptions;
 
   /**
    * @inheritDoc
@@ -42,11 +44,9 @@ class HttpExceptionHandler implements ExceptionHandlerInterface
     if ($exception instanceof HttpException) {
       $statusCode = $exception->getStatus()->code;
       $message = $exception->getMessage();
-
-      error_log($exception->getMessage() . ' in ' . $exception->getFile() . ' on line ' . $exception->getLine() . PHP_EOL . $exception->getTraceAsString() . PHP_EOL . PHP_EOL, 0);
     }
 
-    $this->logger->error($exception->getMessage());
+    $this->logHandledException($exception);
 
     $isProduction = Config::environment() === EnvironmentType::PRODUCTION;
 

--- a/src/Exceptions/Handlers/WhoopsExceptionHandler.php
+++ b/src/Exceptions/Handlers/WhoopsExceptionHandler.php
@@ -7,6 +7,7 @@ use Assegai\Core\Enumerations\EnvironmentType;
 use Assegai\Core\Enumerations\Http\RequestMethod;
 use Assegai\Core\Enumerations\Http\ContentType;
 use Assegai\Core\Exceptions\Handlers\Concerns\EmitsErrorResponses;
+use Assegai\Core\Exceptions\Handlers\Concerns\LogsHandledExceptions;
 use Assegai\Core\Exceptions\Handlers\Support\FrameworkErrorPageRenderer;
 use Assegai\Core\Exceptions\Http\HttpException;
 use Assegai\Core\Exceptions\Interfaces\ExceptionHandlerInterface;
@@ -26,6 +27,7 @@ use Whoops\Run;
 class WhoopsExceptionHandler implements ExceptionHandlerInterface
 {
   use EmitsErrorResponses;
+  use LogsHandledExceptions;
 
   /**
    * WhoopsExceptionHandler constructor.
@@ -42,7 +44,7 @@ class WhoopsExceptionHandler implements ExceptionHandlerInterface
   public function handle(Throwable $exception): void
   {
     $whoops = $this->createWhoopsRun();
-    $this->logger->error($exception->getMessage());
+    $this->logHandledException($exception);
 
     ob_start();
     $renderedBody = $whoops->handleException($exception);

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -53,6 +53,10 @@ class ModuleManager implements SingletonInterface
    */
   protected array $moduleParentMap = [];
   /**
+   * @var array<string, string[]> A map of all direct parent modules keyed by child module class.
+   */
+  protected array $moduleParentsMap = [];
+  /**
    * @var array<string, bool> Cached module provider access decisions keyed by consumer and provider class.
    */
   protected array $moduleProviderAccessCache = [];
@@ -192,6 +196,7 @@ class ModuleManager implements SingletonInterface
       $this->moduleExportsMap = [];
       $this->providerModuleMap = [];
       $this->moduleParentMap = [$rootToken => null];
+      $this->moduleParentsMap = [$rootToken => []];
       $this->moduleProviderAccessCache = [];
       $this->config = [];
       $this->declarationTokens = [];
@@ -257,6 +262,12 @@ class ModuleManager implements SingletonInterface
 
         // Push imports onto the stack for later processing
         foreach ($imports as $import) {
+          $this->moduleParentsMap[$import] ??= [];
+
+          if (!in_array($currentToken, $this->moduleParentsMap[$import], true)) {
+            $this->moduleParentsMap[$import][] = $currentToken;
+          }
+
           if (!array_key_exists($import, $this->moduleParentMap)) {
             $this->moduleParentMap[$import] = $currentToken;
           }
@@ -368,6 +379,17 @@ class ModuleManager implements SingletonInterface
   public function getParentModule(string $moduleClass): ?string
   {
     return $this->moduleParentMap[$moduleClass] ?? null;
+  }
+
+  /**
+   * Returns all direct parent modules for the given module class.
+   *
+   * @param string $moduleClass
+   * @return string[]
+   */
+  public function getParentModules(string $moduleClass): array
+  {
+    return $this->moduleParentsMap[$moduleClass] ?? [];
   }
 
   /**
@@ -692,28 +714,80 @@ class ModuleManager implements SingletonInterface
       }
     }
 
-    $parentModule = $this->getParentModule($consumerModuleClass);
-    $visitedParents = [];
+    return $this->ancestorBranchesExportProvider($consumerModuleClass, $providerClass);
+  }
 
-    while (null !== $parentModule && !in_array($parentModule, $visitedParents, true)) {
-      $visitedParents[] = $parentModule;
+  /**
+   * Determines whether all possible parent branches expose the provider to this module.
+   *
+   * A module class may be imported by multiple parents. Since providers are keyed by class,
+   * parent-derived visibility must be true for every parent branch to avoid import-order leaks.
+   *
+   * @param string $moduleClass
+   * @param string $providerClass
+   * @return bool
+   */
+  private function ancestorBranchesExportProvider(string $moduleClass, string $providerClass): bool
+  {
+    $parents = $this->getParentModules($moduleClass);
 
-      if ($this->moduleExportsProvider($parentModule, $providerClass)) {
-        return true;
-      }
-
-      $parentModule = $this->getParentModule($parentModule);
+    if ([] === $parents) {
+      return false;
     }
 
-    return false;
+    foreach ($parents as $parentModule) {
+      if (!$this->moduleOrAncestorBranchesExportProvider($parentModule, $providerClass)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Determines whether the module or every possible parent branch exports the provider.
+   *
+   * @param string $moduleClass
+   * @param string $providerClass
+   * @param array<int, string> $visitedModules
+   * @return bool
+   */
+  private function moduleOrAncestorBranchesExportProvider(
+    string $moduleClass,
+    string $providerClass,
+    array $visitedModules = [],
+  ): bool
+  {
+    if ($this->moduleExportsProvider($moduleClass, $providerClass)) {
+      return true;
+    }
+
+    if (in_array($moduleClass, $visitedModules, true)) {
+      return false;
+    }
+
+    $visitedModules[] = $moduleClass;
+    $parents = $this->getParentModules($moduleClass);
+
+    if ([] === $parents) {
+      return false;
+    }
+
+    foreach ($parents as $parentModule) {
+      if (!$this->moduleOrAncestorBranchesExportProvider($parentModule, $providerClass, $visitedModules)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**
    * Determines whether the given module exports the provider directly or through a re-exported module.
    *
-   * @param class-string $moduleClass
-   * @param class-string $providerClass
-   * @param array<int, class-string> $visitedModules
+   * @param string $moduleClass
+   * @param string $providerClass
+   * @param array<int, string> $visitedModules
    * @return bool
    */
   private function moduleExportsProvider(string $moduleClass, string $providerClass, array $visitedModules = []): bool

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -53,6 +53,10 @@ class ModuleManager implements SingletonInterface
    */
   protected array $moduleParentMap = [];
   /**
+   * @var array<string, bool> Cached module provider access decisions keyed by consumer and provider class.
+   */
+  protected array $moduleProviderAccessCache = [];
+  /**
    * @var array<class-string> A list of all the controller tokens
    */
   protected array $controllerTokensList = [];
@@ -188,6 +192,7 @@ class ModuleManager implements SingletonInterface
       $this->moduleExportsMap = [];
       $this->providerModuleMap = [];
       $this->moduleParentMap = [$rootToken => null];
+      $this->moduleProviderAccessCache = [];
       $this->config = [];
       $this->declarationTokens = [];
       $stack = [$rootToken]; // Stack to simulate recursion
@@ -441,6 +446,7 @@ class ModuleManager implements SingletonInterface
   {
     $this->providerTokens = [];
     $this->providerModuleMap = [];
+    $this->moduleProviderAccessCache = [];
 
     foreach ($this->moduleTokens as $moduleClass => $module) {
       /** @var array{providers?: string[]} $args */
@@ -640,14 +646,35 @@ class ModuleManager implements SingletonInterface
   /**
    * Determines whether the consumer module can access the given provider.
    *
-   * Providers are visible within their declaring module and across imports only when the
-   * imported module explicitly exports them, either directly or through a re-exported module.
+   * Providers are visible within their declaring module, across imported module exports,
+   * and from a child module to exports declared by its ancestor modules.
    *
    * @param class-string $consumerModuleClass
    * @param class-string $providerClass
    * @return bool
    */
   public function canModuleAccessProvider(string $consumerModuleClass, string $providerClass): bool
+  {
+    $cacheKey = $consumerModuleClass . '::' . $providerClass;
+
+    if (array_key_exists($cacheKey, $this->moduleProviderAccessCache)) {
+      return $this->moduleProviderAccessCache[$cacheKey];
+    }
+
+    return $this->moduleProviderAccessCache[$cacheKey] = $this->resolveModuleProviderAccess(
+      consumerModuleClass: $consumerModuleClass,
+      providerClass: $providerClass,
+    );
+  }
+
+  /**
+   * Resolves whether the consumer module can access the given provider.
+   *
+   * @param class-string $consumerModuleClass
+   * @param class-string $providerClass
+   * @return bool
+   */
+  private function resolveModuleProviderAccess(string $consumerModuleClass, string $providerClass): bool
   {
     $ownerModule = $this->getProviderOwnerModule($providerClass);
 
@@ -663,6 +690,19 @@ class ModuleManager implements SingletonInterface
       if ($this->moduleExportsProvider($importedModule, $providerClass)) {
         return true;
       }
+    }
+
+    $parentModule = $this->getParentModule($consumerModuleClass);
+    $visitedParents = [];
+
+    while (null !== $parentModule && !in_array($parentModule, $visitedParents, true)) {
+      $visitedParents[] = $parentModule;
+
+      if ($this->moduleExportsProvider($parentModule, $providerClass)) {
+        return true;
+      }
+
+      $parentModule = $this->getParentModule($parentModule);
     }
 
     return false;

--- a/src/Rendering/Engines/DefaultTemplateEngine.php
+++ b/src/Rendering/Engines/DefaultTemplateEngine.php
@@ -94,7 +94,7 @@ class DefaultTemplateEngine extends TemplateEngine
         $this->twig = new Environment($this->loader);
         $this->twig->addExtension(new MarkdownExtension());
         $this->twig->addRuntimeLoader(new class implements RuntimeLoaderInterface {
-            public function load($class): ?MarkdownRuntime
+            public function load(string $class): ?MarkdownRuntime
             {
                 if (MarkdownRuntime::class === $class) {
                     return new MarkdownRuntime(new DefaultMarkdown());
@@ -121,7 +121,6 @@ class DefaultTemplateEngine extends TemplateEngine
     public function render(): string
     {
         # Get component attribute instance
-        $props ??= [];
         $componentAttributeInstance = $this->rootComponentAttributeInstance;
         $componentReflection = new ReflectionClass($this->rootComponent);
         $this->componentFilename = $componentReflection->getFileName();
@@ -139,6 +138,7 @@ class DefaultTemplateEngine extends TemplateEngine
         $data = [];
 
         $ctx = new class {
+            /** @var array<string, callable> */
             private array $methods = [];
 
             public function addMethod(string $name, callable $method): void
@@ -146,7 +146,15 @@ class DefaultTemplateEngine extends TemplateEngine
                 $this->methods[$name] = $method;
             }
 
-            public function __call($name, $arguments)
+            public function hasMethod(string $name): bool
+            {
+                return isset($this->methods[$name]);
+            }
+
+            /**
+             * @param array<int, mixed> $arguments
+             */
+            public function __call(string $name, array $arguments): mixed
             {
                 if (isset($this->methods[$name])) {
                     return call_user_func_array($this->methods[$name], $arguments);
@@ -171,37 +179,37 @@ class DefaultTemplateEngine extends TemplateEngine
             $ctx->addMethod($methodName, fn(...$args) => $method->invoke($this->rootComponent, ...$args));
         }
 
-        if (!method_exists($ctx, 'config')) {
+        if (!$ctx->hasMethod('config')) {
             $ctx->addMethod('config', fn(string $path, mixed $default = null, ?string $dirname = null) => config($path, $default, $dirname));
         }
 
-        if (!method_exists($ctx, 'translate')) {
+        if (!$ctx->hasMethod('translate')) {
             $ctx->addMethod('translate', fn(string $id, array $parameters = [], string $domain = '', ?string $locale = null) => translate($id, $parameters, $domain, $locale));
         }
 
-        if (!method_exists($ctx, 'timeAgo')) {
+        if (!$ctx->hasMethod('timeAgo')) {
             $ctx->addMethod('timeAgo', fn(int|string|null $timestamp, ?string $timezone = null) => time_ago($timestamp, $timezone));
         }
 
-        if (!method_exists($ctx, 'env')) {
+        if (!$ctx->hasMethod('env')) {
             $ctx->addMethod('env', fn(string $key, mixed $default = null) => env($key, $default));
         }
 
-        if (!method_exists($ctx, 'getLang')) {
+        if (!$ctx->hasMethod('getLang')) {
             $ctx->addMethod('getLang', fn() => Request::current()->getLang());
         }
 
         $webComponentPropsMethod = fn(mixed $props = []) => new Markup(wc_props($props), 'UTF-8');
 
-        if (!method_exists($ctx, 'webComponentProps')) {
+        if (!$ctx->hasMethod('webComponentProps')) {
             $ctx->addMethod('webComponentProps', $webComponentPropsMethod);
         }
 
-        if (!method_exists($ctx, 'wcProps')) {
+        if (!$ctx->hasMethod('wcProps')) {
             $ctx->addMethod('wcProps', $webComponentPropsMethod);
         }
 
-        if (!method_exists($ctx, 'webComponentBundleUrl')) {
+        if (!$ctx->hasMethod('webComponentBundleUrl')) {
             $ctx->addMethod('webComponentBundleUrl', fn() => web_component_bundle_url());
         }
 
@@ -219,32 +227,29 @@ class DefaultTemplateEngine extends TemplateEngine
 
         $this->setData($data);
 
-        if ($this->meta) {
-            extract($this->meta);
-        }
-
         if (!$this->title) {
-            $this->title = $title ?? $_ENV['DOCUMENT_TITLE'] ?? $this->getAppDocumentConfigValue('title', 'AssegaiPHP');
+            $this->title = $this->getMetaString('title') ?? $_ENV['DOCUMENT_TITLE'] ?? $this->getAppDocumentConfigValue('title', 'AssegaiPHP');
         }
 
         if (!$this->description) {
-            $this->description = $description ?? $_ENV['DOCUMENT_DESCRIPTION'] ?? $this->getAppDocumentConfigValue('description', 'AssegaiPHP Application');
+            $this->description = $this->getMetaString('description') ?? $_ENV['DOCUMENT_DESCRIPTION'] ?? $this->getAppDocumentConfigValue('description', 'AssegaiPHP Application');
         }
 
         if (!$this->keywords) {
-            $this->keywords = $keywords ?? $_ENV['DOCUMENT_KEYWORDS'] ?? $this->getAppDocumentConfigValue('keywords', 'AssegaiPHP, PHP, Framework');
+            $this->keywords = $this->getMetaString('keywords') ?? $_ENV['DOCUMENT_KEYWORDS'] ?? $this->getAppDocumentConfigValue('keywords', 'AssegaiPHP, PHP, Framework');
         }
 
         if (!$this->author) {
-            $this->author = $author ?? $_ENV['DOCUMENT_AUTHOR'] ?? $this->getAppDocumentConfigValue('author', '');
+            $this->author = $this->getMetaString('author') ?? $_ENV['DOCUMENT_AUTHOR'] ?? $this->getAppDocumentConfigValue('author', '');
         }
 
-        $documentProps = DocumentProperties::fromArray(is_array($props ?? null) ? $props : []);
-        $lang ??= $documentProps->lang ?: Request::current()->getLang();
+        $rawDocumentProps = $this->meta['props'] ?? [];
+        $documentProps = DocumentProperties::fromArray(is_array($rawDocumentProps) ? $rawDocumentProps : []);
+        $lang = $this->getMetaString('lang') ?? ($documentProps->lang ?: Request::current()->getLang());
         $headAssets = $documentProps->generateHeadAssetTags();
 
-        if (is_string($props ?? null) && trim($props) !== '') {
-            $headAssets .= trim($props) . PHP_EOL;
+        if (is_string($rawDocumentProps) && trim($rawDocumentProps) !== '') {
+            $headAssets .= trim($rawDocumentProps) . PHP_EOL;
         }
 
         # Render template
@@ -256,7 +261,7 @@ class DefaultTemplateEngine extends TemplateEngine
         $bodyScripts = $documentProps->generateBodyScriptTags() . $documentProps->generateBodyScriptImportTags();
         $webComponentBundleTag = $this->loadWebComponentBundle();
         $escapedTitle = htmlspecialchars($this->title, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-        $htmxLink ??= $documentProps->htmxLink ?? '';
+        $htmxLink = $this->getMetaString('htmxLink') ?? $documentProps->htmxLink;
         $htmxScriptTag = is_string($htmxLink) && trim($htmxLink) !== ''
             ? '<script src="' . htmlspecialchars(trim($htmxLink), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"></script>'
             : '';
@@ -280,6 +285,13 @@ class DefaultTemplateEngine extends TemplateEngine
   </body>
 </html>
 START;
+    }
+
+    private function getMetaString(string $key): ?string
+    {
+        $value = $this->meta[$key] ?? null;
+
+        return is_scalar($value) || $value instanceof \Stringable ? (string)$value : null;
     }
 
     private function getAppDocumentConfigValue(string $key, mixed $default = null): mixed

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -264,6 +264,7 @@ final class Router
      * @param Request $request
      * @param string $moduleClass
      * @param ReflectionClass|null $fallbackController
+     * @param array<string, bool> $visitedModules
      * @return ReflectionClass|null
      * @throws HttpException
      * @throws ReflectionException
@@ -271,9 +272,15 @@ final class Router
     private function getActivatedControllerToken(
         Request          $request,
         string           $moduleClass,
-        ?ReflectionClass $fallbackController = null
+        ?ReflectionClass $fallbackController = null,
+        array            $visitedModules = []
     ): ?ReflectionClass
     {
+        if (isset($visitedModules[$moduleClass])) {
+            return null;
+        }
+
+        $visitedModules[$moduleClass] = true;
         $bestMatch = $fallbackController;
 
         if (!is_null($bestMatch) && !$this->canActivateController($bestMatch, $request)) {
@@ -289,6 +296,10 @@ final class Router
         }
 
         foreach ($this->moduleManager->getImportedModules($moduleClass) as $importedModuleClass) {
+            if (isset($visitedModules[$importedModuleClass])) {
+                continue;
+            }
+
             if (!$this->requestMatchesModuleBranch($request, $importedModuleClass)) {
                 continue;
             }
@@ -297,6 +308,7 @@ final class Router
                 request: $request,
                 moduleClass: $importedModuleClass,
                 fallbackController: $bestMatch,
+                visitedModules: $visitedModules,
             );
 
             $bestMatch = $this->preferControllerMatch($request, $bestMatch, $branchMatch);

--- a/tests/Mocks/MockController.php
+++ b/tests/Mocks/MockController.php
@@ -166,6 +166,53 @@ class NestedAppModule
 {
 }
 
+#[Controller('v1/workspaces')]
+class CyclicWorkspaceController
+{
+  #[Get(':workspace_id')]
+  public function findById(#[Param('workspace_id')] int $workspaceId): string
+  {
+    return "workspace-$workspaceId";
+  }
+}
+
+#[Controller(':workspace_id/vendors')]
+class CyclicVendorController
+{
+  #[Get(':vendor_id')]
+  public function findById(
+    #[Param('workspace_id')] int $workspaceId,
+    #[Param('vendor_id')] int $vendorId,
+  ): string
+  {
+    return "vendor-$workspaceId-$vendorId";
+  }
+}
+
+#[Module(
+  controllers: [CyclicWorkspaceController::class],
+  imports: [CyclicVendorModule::class],
+)]
+class CyclicWorkspaceModule
+{
+}
+
+#[Module(
+  controllers: [CyclicVendorController::class],
+  imports: [CyclicWorkspaceModule::class],
+)]
+class CyclicVendorModule
+{
+}
+
+#[Module(
+  controllers: [NestedRootController::class],
+  imports: [CyclicWorkspaceModule::class],
+)]
+class CyclicRoutingAppModule
+{
+}
+
 #[Controller('users')]
 class ConstrainedUsersController
 {

--- a/tests/Mocks/MockInjector.php
+++ b/tests/Mocks/MockInjector.php
@@ -303,6 +303,110 @@ class ProviderOwnershipOrderingAppModule
 {
 }
 
+
+#[Injectable]
+class ParentExportedService
+{
+  public string $value = 'parent-export';
+}
+
+#[Injectable]
+class ChildUsesParentExportedService
+{
+  public function __construct(
+    public ParentExportedService $parentService,
+  ) {
+  }
+}
+
+#[Module(
+  providers: [
+    ChildUsesParentExportedService::class,
+  ],
+  controllers: [],
+  imports: [],
+)]
+class ChildConsumesParentExportModule
+{
+}
+
+#[Module(
+  providers: [
+    ParentExportedService::class,
+  ],
+  controllers: [],
+  imports: [
+    ChildConsumesParentExportModule::class,
+  ],
+  exports: [
+    ParentExportedService::class,
+  ],
+)]
+class ParentExportModule
+{
+}
+
+#[Module(
+  providers: [],
+  controllers: [],
+  imports: [
+    ParentExportModule::class,
+  ],
+)]
+class ParentExportVisibilityAppModule
+{
+}
+
+#[Injectable]
+class ParentPrivateService
+{
+  public string $value = 'parent-private';
+}
+
+#[Injectable(options: ['scope' => Scope::TRANSIENT, 'durable' => false])]
+class ChildUsesParentPrivateService
+{
+  public function __construct(
+    public ParentPrivateService $parentService,
+  ) {
+  }
+}
+
+#[Module(
+  providers: [
+    ChildUsesParentPrivateService::class,
+  ],
+  controllers: [],
+  imports: [],
+)]
+class ChildConsumesParentPrivateModule
+{
+}
+
+#[Module(
+  providers: [
+    ParentPrivateService::class,
+  ],
+  controllers: [],
+  imports: [
+    ChildConsumesParentPrivateModule::class,
+  ],
+)]
+class ParentPrivateModule
+{
+}
+
+#[Module(
+  providers: [],
+  controllers: [],
+  imports: [
+    ParentPrivateModule::class,
+  ],
+)]
+class ParentPrivateVisibilityAppModule
+{
+}
+
 #[Module(
   providers: [
     FrameworkAwareService::class,

--- a/tests/Mocks/MockInjector.php
+++ b/tests/Mocks/MockInjector.php
@@ -408,6 +408,41 @@ class ParentPrivateVisibilityAppModule
 }
 
 #[Module(
+  providers: [],
+  controllers: [],
+  imports: [
+    ChildConsumesParentExportModule::class,
+  ],
+)]
+class ParentWithoutExportModule
+{
+}
+
+#[Module(
+  providers: [],
+  controllers: [],
+  imports: [
+    ParentExportModule::class,
+    ParentWithoutExportModule::class,
+  ],
+)]
+class SharedChildMixedParentsAppModule
+{
+}
+
+#[Module(
+  providers: [],
+  controllers: [],
+  imports: [
+    ParentWithoutExportModule::class,
+    ParentExportModule::class,
+  ],
+)]
+class SharedChildMixedParentsReversedAppModule
+{
+}
+
+#[Module(
   providers: [
     FrameworkAwareService::class,
     FrameworkAwareContractsService::class,

--- a/tests/Unit/ExceptionHandlersCest.php
+++ b/tests/Unit/ExceptionHandlersCest.php
@@ -183,6 +183,82 @@ class ExceptionHandlersCest
     $I->assertSame('{"message":"rendered"}', $handler->emissions[0]['body']);
   }
 
+  public function testWhoopsExceptionHandlerLogsHttpClientErrorsAsDebug(UnitTester $I): void
+  {
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $records = [];
+    $logger = $this->createRecordingLogger($records);
+
+    $handler = new class($logger) extends WhoopsExceptionHandler {
+      public array $emissions = [];
+
+      public function __construct(LoggerInterface $logger)
+      {
+        parent::__construct($logger);
+      }
+
+      protected function isCliContext(): bool
+      {
+        return false;
+      }
+
+      protected function emitErrorResponse(string $body, ContentType $contentType, int $statusCode): void
+      {
+        $this->emissions[] = [
+          'body' => $body,
+          'status' => $statusCode,
+          'content_type' => $contentType->value,
+        ];
+      }
+    };
+
+    $handler->handle(new NotFoundException('/.well-known/appspecific/com.chrome.devtools.json'));
+
+    $I->assertCount(1, $handler->emissions);
+    $I->assertSame(404, $handler->emissions[0]['status']);
+    $I->assertCount(1, $records);
+    $I->assertSame('debug', $records[0]['level']);
+    $I->assertStringContainsString('/.well-known/appspecific/com.chrome.devtools.json', $records[0]['message']);
+  }
+
+  public function testWhoopsExceptionHandlerLogsUnexpectedFailuresAsErrors(UnitTester $I): void
+  {
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $records = [];
+    $logger = $this->createRecordingLogger($records);
+
+    $handler = new class($logger) extends WhoopsExceptionHandler {
+      public array $emissions = [];
+
+      public function __construct(LoggerInterface $logger)
+      {
+        parent::__construct($logger);
+      }
+
+      protected function isCliContext(): bool
+      {
+        return false;
+      }
+
+      protected function emitErrorResponse(string $body, ContentType $contentType, int $statusCode): void
+      {
+        $this->emissions[] = [
+          'body' => $body,
+          'status' => $statusCode,
+          'content_type' => $contentType->value,
+        ];
+      }
+    };
+
+    $handler->handle(new RuntimeException('Boom'));
+
+    $I->assertCount(1, $handler->emissions);
+    $I->assertSame(500, $handler->emissions[0]['status']);
+    $I->assertCount(1, $records);
+    $I->assertSame('error', $records[0]['level']);
+    $I->assertSame('Boom', $records[0]['message']);
+  }
+
   public function testFrameworkErrorPageRendererBuildsHtmlShell(UnitTester $I): void
   {
     $html = FrameworkErrorPageRenderer::render(404, 'Not Found', 'Page not found', 'The page you requested does not exist.');
@@ -262,6 +338,42 @@ class ExceptionHandlersCest
     $I->assertStringNotContainsString('Details', $handler->emissions[0]['body']);
   }
 
+  public function testHttpExceptionHandlerLogsHttpClientErrorsAsDebug(UnitTester $I): void
+  {
+    $_ENV['ENV'] = 'PROD';
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_SERVER['CONTENT_TYPE'] = '';
+    $_SERVER['HTTP_ACCEPT'] = 'text/html';
+    $records = [];
+    $logger = $this->createRecordingLogger($records);
+
+    $handler = new class($logger) extends HttpExceptionHandler {
+      public array $emissions = [];
+
+      public function __construct(LoggerInterface $logger)
+      {
+        parent::__construct($logger);
+      }
+
+      protected function emitErrorResponse(string $body, ContentType $contentType, int $statusCode): void
+      {
+        $this->emissions[] = [
+          'body' => $body,
+          'status' => $statusCode,
+          'content_type' => $contentType->value,
+        ];
+      }
+    };
+
+    $handler->handle(new NotFoundException('missing-style.css'));
+
+    $I->assertCount(1, $handler->emissions);
+    $I->assertSame(404, $handler->emissions[0]['status']);
+    $I->assertCount(1, $records);
+    $I->assertSame('debug', $records[0]['level']);
+    $I->assertStringContainsString('/missing-style.css', $records[0]['message']);
+  }
+
   public function testHttpExceptionHandlerShowsForbiddenFor403(UnitTester $I): void
   {
     $_ENV['ENV'] = 'PROD';
@@ -303,6 +415,29 @@ class ExceptionHandlersCest
     return new class extends AbstractLogger {
       public function log($level, string|\Stringable $message, array $context = []): void
       {
+      }
+    };
+  }
+
+  /**
+   * @param array<int, array{level: mixed, message: string}> $records
+   */
+  private function createRecordingLogger(array &$records): LoggerInterface
+  {
+    return new class($records) extends AbstractLogger {
+      /**
+       * @param array<int, array{level: mixed, message: string}> $records
+       */
+      public function __construct(private array &$records)
+      {
+      }
+
+      public function log($level, string|\Stringable $message, array $context = []): void
+      {
+        $this->records[] = [
+          'level' => $level,
+          'message' => (string)$message,
+        ];
       }
     };
   }

--- a/tests/Unit/InjectorCest.php
+++ b/tests/Unit/InjectorCest.php
@@ -20,11 +20,15 @@ use Assegai\Core\Runtimes\RuntimeContext;
 use Assegai\Core\Routing\Router;
 use Assegai\Core\Session;
 use Mocks\AttributeResolvedService;
+use Mocks\ChildUsesParentExportedService;
+use Mocks\ChildUsesParentPrivateService;
 use Mocks\ExplicitRequestScopedService;
 use Mocks\ExportVisibilityAppModule;
 use Mocks\FrameworkAwareAppModule;
 use Mocks\FrameworkAwareContractsService;
 use Mocks\FrameworkAwareService;
+use Mocks\ParentExportVisibilityAppModule;
+use Mocks\ParentPrivateVisibilityAppModule;
 use Mocks\ProviderOwnershipOrderingAppModule;
 use Mocks\RequestCapturingService;
 use Mocks\ResolverAwareAppModule;
@@ -344,6 +348,28 @@ class InjectorCest
     $I->assertSame(Request::current(), $secondExplicitScoped->request);
     $I->assertNull($injector->get(RequestCapturingService::class));
     $I->assertNull($injector->get(ExplicitRequestScopedService::class));
+  }
+
+  public function testChildModulesCanInjectParentModuleExports(UnitTester $I): void
+  {
+    $app = AssegaiFactory::create(ParentExportVisibilityAppModule::class);
+    $app->boot();
+
+    $service = Injector::getInstance()->resolve(ChildUsesParentExportedService::class);
+
+    $I->assertInstanceOf(ChildUsesParentExportedService::class, $service);
+    $I->assertSame('parent-export', $service->parentService->value);
+  }
+
+  public function testChildModulesCannotInjectParentPrivateProviders(UnitTester $I): void
+  {
+    $app = AssegaiFactory::create(ParentPrivateVisibilityAppModule::class);
+    $app->boot();
+
+    $I->expectThrowable(
+      \Assegai\Core\Exceptions\Container\ResolveException::class,
+      fn() => Injector::getInstance()->resolve(ChildUsesParentPrivateService::class),
+    );
   }
 
   public function testImportedModulesOnlyExposeExportedProviders(UnitTester $I): void

--- a/tests/Unit/InjectorCest.php
+++ b/tests/Unit/InjectorCest.php
@@ -36,6 +36,8 @@ use Mocks\ResolverOnlyAwareAppModule;
 use Mocks\ResolverResolvedService;
 use Mocks\RootPrivateConsumerService;
 use Mocks\RootPublicConsumerService;
+use Mocks\SharedChildMixedParentsAppModule;
+use Mocks\SharedChildMixedParentsReversedAppModule;
 use ReflectionException;
 use ReflectionProperty;
 use Tests\Support\UnitTester;
@@ -369,6 +371,22 @@ class InjectorCest
     $I->expectThrowable(
       \Assegai\Core\Exceptions\Container\ResolveException::class,
       fn() => Injector::getInstance()->resolve(ChildUsesParentPrivateService::class),
+    );
+  }
+
+  public function testSharedChildModulesCannotInjectParentExportsFromOnlyOneBranch(UnitTester $I): void
+  {
+    $I->expectThrowable(
+      \Assegai\Core\Exceptions\Container\ResolveException::class,
+      fn() => AssegaiFactory::create(SharedChildMixedParentsAppModule::class)->boot(),
+    );
+  }
+
+  public function testSharedChildParentExportChecksAreImportOrderIndependent(UnitTester $I): void
+  {
+    $I->expectThrowable(
+      \Assegai\Core\Exceptions\Container\ResolveException::class,
+      fn() => AssegaiFactory::create(SharedChildMixedParentsReversedAppModule::class)->boot(),
     );
   }
 

--- a/tests/Unit/RouterCest.php
+++ b/tests/Unit/RouterCest.php
@@ -18,6 +18,8 @@ use Codeception\Attribute\Skip;
 use Mocks\AllRoutesAppModule;
 use Mocks\MockController;
 use Mocks\ConstrainedRoutingAppModule;
+use Mocks\CyclicRoutingAppModule;
+use Mocks\CyclicVendorController;
 use Mocks\ConstrainedUsersController;
 use Mocks\InvalidConstraintAppModule;
 use Mocks\LegacyAppModule;
@@ -155,6 +157,21 @@ class RouterCest
 
     $I->assertInstanceOf(NestedFeaturesController::class, $controller);
     $I->assertSame('feature-1', $response->getBody());
+  }
+
+  /**
+   * @throws ReflectionException
+   * @throws NotFoundException
+   * @throws HttpException
+   * @throws ContainerException
+   * @throws EntryNotFoundException
+   */
+  public function testCyclicModuleImportsDoNotRecurseDuringControllerActivation(UnitTester $I): void
+  {
+    $result = $this->dispatch('/v1/workspaces/1/vendors/2', CyclicRoutingAppModule::class);
+
+    $I->assertInstanceOf(CyclicVendorController::class, $result['controller']);
+    $I->assertSame('vendor-1-2', $result['response']->getBody());
   }
 
   /**

--- a/tests/Unit/WebComponentsCest.php
+++ b/tests/Unit/WebComponentsCest.php
@@ -317,6 +317,50 @@ TWIG
     $I->assertStringContainsString('<html lang="fr">', $html);
   }
 
+  public function testDefaultTemplateEngineUsesStructuredComponentDocumentProps(UnitTester $I): void
+  {
+    $componentClass = $this->writeComponentWithMeta('StructuredProps', <<<'PHP'
+[
+  'props' => [
+    'headScriptUrls' => ['/js/page.js'],
+    'bodyScriptUrls' => ['/js/page-body.js'],
+    'lang' => 'es',
+    'htmxLink' => '',
+  ],
+]
+PHP);
+
+    $component = new $componentClass();
+    $engine = new DefaultTemplateEngine();
+
+    $html = $engine
+      ->setRootComponent($component)
+      ->render();
+
+    $I->assertStringContainsString("<script defer src='/js/page.js'></script>", $html);
+    $I->assertStringContainsString("<script src='/js/page-body.js' defer></script>", $html);
+    $I->assertStringContainsString('<html lang="es">', $html);
+  }
+
+  public function testDefaultTemplateEnginePreservesLegacyRawHeadProps(UnitTester $I): void
+  {
+    $componentClass = $this->writeComponentWithMeta('RawHeadProps', <<<'PHP'
+[
+  'props' => '<meta name="legacy-head" content="ok">',
+  'htmxLink' => '',
+]
+PHP);
+
+    $component = new $componentClass();
+    $engine = new DefaultTemplateEngine();
+
+    $html = $engine
+      ->setRootComponent($component)
+      ->render();
+
+    $I->assertStringContainsString('<meta name="legacy-head" content="ok">', $html);
+  }
+
   public function testTheDefaultTemplateEngineSkipsEmptyConfiguredBodyScriptUrls(UnitTester $I): void
   {
     unset($_ENV['app']);
@@ -342,6 +386,42 @@ TWIG
 
     $I->assertStringNotContainsString("<script src='' defer></script>", $html);
     $I->assertStringNotContainsString('<script src=""></script>', $html);
+  }
+
+  private function writeComponentWithMeta(string $suffix, string $meta): string
+  {
+    $componentBasename = 'TestWebComponent' . preg_replace('/[^A-Za-z0-9]/', '', $suffix) . str_replace('.', '', uniqid('', true));
+    $componentFilename = $componentBasename . '.php';
+    $templateFilename = $componentBasename . '.twig';
+    $selector = strtolower(preg_replace('/(?<!^)[A-Z]/', '-$0', $suffix));
+    $componentClass = "Tests\\WebComponents\\$componentBasename";
+
+    file_put_contents($this->workspace . '/src/' . $templateFilename, '<p>{{ name }}</p>');
+    file_put_contents(
+      $this->workspace . '/src/' . $componentFilename,
+      <<<PHP
+<?php
+
+namespace Tests\WebComponents;
+
+use Assegai\Core\Attributes\Component;
+use Assegai\Core\Components\AssegaiComponent;
+
+#[Component(
+  selector: 'app-$selector',
+  templateUrl: '$templateFilename',
+  meta: $meta
+)]
+class $componentBasename extends AssegaiComponent
+{
+  public string \$name = 'Ada';
+}
+PHP
+    );
+
+    require_once $this->workspace . '/src/' . $componentFilename;
+
+    return $componentClass;
   }
 
   /**


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to exception handling, module provider visibility, and routing in the codebase. The most significant changes include the addition of a shared logging concern for exception handlers, enhancements to module provider access logic (especially for parent-child module relationships), prevention of infinite recursion in routing due to cyclic module imports, and comprehensive new tests to verify these behaviors.

**Exception Handling Improvements**
* Introduced a `LogsHandledExceptions` trait to centralize how handled exceptions are logged, distinguishing between client errors (logged as debug) and server errors (logged as error), and integrated it into both `HttpExceptionHandler` and `WhoopsExceptionHandler` for consistent behavior. [[1]](diffhunk://#diff-98fb939ce6245b46795ddd0f8a17eade490fc95b0f0974a5a50d71e13f457cc8R1-R23) [[2]](diffhunk://#diff-25af556b5dc96917afffa51ed07fb29c8738cacbc4886858ec31d99f81566d74R9) [[3]](diffhunk://#diff-25af556b5dc96917afffa51ed07fb29c8738cacbc4886858ec31d99f81566d74R27) [[4]](diffhunk://#diff-25af556b5dc96917afffa51ed07fb29c8738cacbc4886858ec31d99f81566d74L45-R49) [[5]](diffhunk://#diff-3fc2fc09b51f8e4a6da5bf9e763e7ee23deac573fff6bf140ccea55d41ad6a68R10) [[6]](diffhunk://#diff-3fc2fc09b51f8e4a6da5bf9e763e7ee23deac573fff6bf140ccea55d41ad6a68R30) [[7]](diffhunk://#diff-3fc2fc09b51f8e4a6da5bf9e763e7ee23deac573fff6bf140ccea55d41ad6a68L45-R47)
* Added unit tests to verify that exception handlers log HTTP client errors as debug and unexpected failures as errors. [[1]](diffhunk://#diff-cb7ea59836fb7f649094dd304984c8d4c90ab464ec4c788914a4870451d84693R186-R261) [[2]](diffhunk://#diff-cb7ea59836fb7f649094dd304984c8d4c90ab464ec4c788914a4870451d84693R341-R376) [[3]](diffhunk://#diff-cb7ea59836fb7f649094dd304984c8d4c90ab464ec4c788914a4870451d84693R421-R443)

**Module Provider Access & Visibility**
* Enhanced the `ModuleManager` logic to allow child modules to access providers exported by their ancestor (parent) modules, using a cache for access decisions to improve performance and correctness. Also, ensured that caches are reset during module token list builds. [[1]](diffhunk://#diff-b0e65ed7bb53ae9d43fb81944789f1fe9beb7f5c337140ec8fab2c3248062b88R55-R58) [[2]](diffhunk://#diff-b0e65ed7bb53ae9d43fb81944789f1fe9beb7f5c337140ec8fab2c3248062b88R195) [[3]](diffhunk://#diff-b0e65ed7bb53ae9d43fb81944789f1fe9beb7f5c337140ec8fab2c3248062b88R449) [[4]](diffhunk://#diff-b0e65ed7bb53ae9d43fb81944789f1fe9beb7f5c337140ec8fab2c3248062b88L643-R677) [[5]](diffhunk://#diff-b0e65ed7bb53ae9d43fb81944789f1fe9beb7f5c337140ec8fab2c3248062b88R695-R707)
* Added new mock modules and services to test and demonstrate parent-child provider export and visibility, including both exported and private provider scenarios.
* Added unit tests to confirm that child modules can inject parent module exports, but cannot inject parent-private providers. [[1]](diffhunk://#diff-d341c8e14c318efc0c48c034d1c330ccd5e3b09fefae7192cf1f8abb56970652R23-R31) [[2]](diffhunk://#diff-d341c8e14c318efc0c48c034d1c330ccd5e3b09fefae7192cf1f8abb56970652R353-R374)

**Routing Robustness**
* Updated the router logic to track visited modules during controller activation, preventing infinite recursion in the presence of cyclic module imports. [[1]](diffhunk://#diff-cc75cf1c7e7edc826fe7fbc1a2d190a5e8628666c5108e2566945c90e85b03adR267-R283) [[2]](diffhunk://#diff-cc75cf1c7e7edc826fe7fbc1a2d190a5e8628666c5108e2566945c90e85b03adR299-R302) [[3]](diffhunk://#diff-cc75cf1c7e7edc826fe7fbc1a2d190a5e8628666c5108e2566945c90e85b03adR311)
* Added mock modules and controllers to simulate cyclic routing structures for testing. [[1]](diffhunk://#diff-790c548b0b442a9beced6944793cf7715222e7c25704c923365bbfb0abf9f62aR169-R215) [[2]](diffhunk://#diff-b48b4683f331f6120a17df4c8a07d05da056f3c86ca110913fa203dfc9e60b71R21-R22)

These changes collectively improve the robustness, maintainability, and correctness of exception handling, dependency injection, and routing in the framework.