### PR TITLE
Enhance provider access failure descriptions and add library modules

### DIFF
--- a/src/Injector.php
+++ b/src/Injector.php
@@ -570,13 +570,11 @@ final class Injector implements ITokenStoreOwner, IContainer
       return;
     }
 
-    $ownerModule = $moduleManager->getProviderOwnerModule($dependencyId) ?? 'an inaccessible module';
-
     throw new ContainerException(sprintf(
-      "%s cannot access %s because %s does not export it.",
+      "%s cannot access %s: %s",
       $consumerId,
       $dependencyId,
-      $ownerModule,
+      $moduleManager->describeProviderAccessFailure($consumerModule, $dependencyId),
     ));
   }
 

--- a/src/ModuleManager.php
+++ b/src/ModuleManager.php
@@ -690,10 +690,62 @@ class ModuleManager implements SingletonInterface
   }
 
   /**
+   * Describes why a module provider access check failed.
+   *
+   * @param string $consumerModuleClass
+   * @param string $providerClass
+   * @return string
+   */
+  public function describeProviderAccessFailure(string $consumerModuleClass, string $providerClass): string
+  {
+    $ownerModule = $this->getProviderOwnerModule($providerClass);
+
+    if (null === $ownerModule) {
+      return sprintf(
+        "%s is not registered as a provider in the active module graph.",
+        $providerClass,
+      );
+    }
+
+    if (!$this->moduleExportsProvider($ownerModule, $providerClass)) {
+      return sprintf(
+        "%s declares %s but does not export it.",
+        $ownerModule,
+        $providerClass,
+      );
+    }
+
+    $hiddenParentBranches = [];
+
+    foreach ($this->getParentModules($consumerModuleClass) as $parentModule) {
+      if (!$this->moduleOrAncestorBranchesExportProvider($parentModule, $providerClass)) {
+        $hiddenParentBranches[] = $parentModule;
+      }
+    }
+
+    if ([] !== $hiddenParentBranches) {
+      return sprintf(
+        "%s exports %s, but it is not visible to %s through every parent branch. Re-export it from %s or one of its ancestors.",
+        $ownerModule,
+        $providerClass,
+        $consumerModuleClass,
+        implode(', ', $hiddenParentBranches),
+      );
+    }
+
+    return sprintf(
+      "%s exports %s, but %s does not import a module that exports it and no ancestor module re-exports it.",
+      $ownerModule,
+      $providerClass,
+      $consumerModuleClass,
+    );
+  }
+
+  /**
    * Resolves whether the consumer module can access the given provider.
    *
-   * @param class-string $consumerModuleClass
-   * @param class-string $providerClass
+   * @param string $consumerModuleClass
+   * @param string $providerClass
    * @return bool
    */
   private function resolveModuleProviderAccess(string $consumerModuleClass, string $providerClass): bool

--- a/tests/Mocks/MockInjector.php
+++ b/tests/Mocks/MockInjector.php
@@ -442,6 +442,68 @@ class SharedChildMixedParentsReversedAppModule
 {
 }
 
+#[Injectable]
+class LibraryCatalogService
+{
+  public string $value = 'catalog';
+}
+
+#[Module(
+  providers: [
+    LibraryCatalogService::class,
+  ],
+  controllers: [],
+  imports: [],
+  exports: [
+    LibraryCatalogService::class,
+  ],
+)]
+class LibraryCatalogModule
+{
+}
+
+#[Injectable(options: ['scope' => Scope::TRANSIENT, 'durable' => false])]
+class LibraryReaderService
+{
+  public function __construct(
+    public LibraryCatalogService $catalogService,
+  ) {
+  }
+}
+
+#[Module(
+  providers: [
+    LibraryReaderService::class,
+  ],
+  controllers: [],
+  imports: [],
+)]
+class LibraryReaderModule
+{
+}
+
+#[Module(
+  providers: [],
+  controllers: [],
+  imports: [
+    LibraryCatalogModule::class,
+    LibraryReaderModule::class,
+  ],
+)]
+class LibraryFeatureModule
+{
+}
+
+#[Module(
+  providers: [],
+  controllers: [],
+  imports: [
+    LibraryFeatureModule::class,
+  ],
+)]
+class LibraryFeatureAppModule
+{
+}
 #[Module(
   providers: [
     FrameworkAwareService::class,

--- a/tests/Unit/InjectorCest.php
+++ b/tests/Unit/InjectorCest.php
@@ -27,7 +27,13 @@ use Mocks\ExportVisibilityAppModule;
 use Mocks\FrameworkAwareAppModule;
 use Mocks\FrameworkAwareContractsService;
 use Mocks\FrameworkAwareService;
+use Mocks\LibraryCatalogModule;
+use Mocks\LibraryFeatureAppModule;
+use Mocks\LibraryFeatureModule;
+use Mocks\LibraryReaderModule;
+use Mocks\LibraryReaderService;
 use Mocks\ParentExportVisibilityAppModule;
+use Mocks\ParentPrivateModule;
 use Mocks\ParentPrivateVisibilityAppModule;
 use Mocks\ProviderOwnershipOrderingAppModule;
 use Mocks\RequestCapturingService;
@@ -368,10 +374,33 @@ class InjectorCest
     $app = AssegaiFactory::create(ParentPrivateVisibilityAppModule::class);
     $app->boot();
 
-    $I->expectThrowable(
-      \Assegai\Core\Exceptions\Container\ResolveException::class,
-      fn() => Injector::getInstance()->resolve(ChildUsesParentPrivateService::class),
-    );
+    try {
+      Injector::getInstance()->resolve(ChildUsesParentPrivateService::class);
+      $I->fail('Expected private parent provider resolution to fail.');
+    } catch (\Assegai\Core\Exceptions\Container\ResolveException $exception) {
+      $I->assertStringContainsString(ParentPrivateModule::class, $exception->getMessage());
+      $I->assertStringContainsString('declares', $exception->getMessage());
+      $I->assertStringContainsString('does not export', $exception->getMessage());
+    }
+  }
+
+  public function testExportedSiblingProvidersReportMissingParentReExport(UnitTester $I): void
+  {
+    $app = AssegaiFactory::create(LibraryFeatureAppModule::class);
+    $app->boot();
+
+    try {
+      Injector::getInstance()->resolve(LibraryReaderService::class);
+      $I->fail('Expected sibling provider resolution without a parent re-export to fail.');
+    } catch (\Assegai\Core\Exceptions\Container\ResolveException $exception) {
+      $I->assertStringContainsString(LibraryCatalogModule::class, $exception->getMessage());
+      $I->assertStringContainsString(LibraryReaderModule::class, $exception->getMessage());
+      $I->assertStringContainsString(LibraryFeatureModule::class, $exception->getMessage());
+      $I->assertStringContainsString('exports', $exception->getMessage());
+      $I->assertStringContainsString('not visible', $exception->getMessage());
+      $I->assertStringContainsString('Re-export', $exception->getMessage());
+      $I->assertStringNotContainsString('does not export it', $exception->getMessage());
+    }
   }
 
   public function testSharedChildModulesCannotInjectParentExportsFromOnlyOneBranch(UnitTester $I): void


### PR DESCRIPTION
This pull request improves error reporting for module provider access failures in the dependency injection system and adds comprehensive tests for new error scenarios. The main changes include implementing a detailed explanation for why a provider is inaccessible, updating the exception message to use this explanation, and adding new test modules and test cases to verify the improved error messages.

**Error reporting improvements:**

* Added a new method `describeProviderAccessFailure` to `ModuleManager` that generates detailed explanations for why a provider is inaccessible, covering cases such as missing exports, lack of re-exports in parent branches, and unregistered providers.
* Updated the exception message in `Injector.php` to use the new detailed explanation from `describeProviderAccessFailure`, making error messages more informative and actionable.

**Testing enhancements:**

* Added new mock modules and services (`LibraryCatalogService`, `LibraryCatalogModule`, `LibraryReaderService`, `LibraryReaderModule`, `LibraryFeatureModule`, `LibraryFeatureAppModule`) to test complex module import/export scenarios.
* Improved an existing test to check the contents of the error message when a child module tries to inject a non-exported parent provider, ensuring the error message includes relevant module names and phrases.
* Added a new test (`testExportedSiblingProvidersReportMissingParentReExport`) to verify that the error message correctly reports when a sibling provider is not visible due to a missing parent re-export, checking for specific module names and explanation phrases.

**Test infrastructure:**

* Registered the new mock modules and services in the unit test file to support the new and updated test cases.