### PR TITLE
Implement configurable session handling and security enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ Then use Core directly when you want to understand or extend the framework runti
 <?php
 // <path-to-project>/index.php
 
-if (!isset($_GET['path']) || $_GET['path'] === '') {
-  $_GET['path'] = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
-}
+$_GET['path'] = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
 
 require_once __DIR__ . '/bootstrap.php';
 ```

--- a/docs/api-docs-and-clients.md
+++ b/docs/api-docs-and-clients.md
@@ -53,7 +53,7 @@ Those runtime endpoints do not require an exported file on disk.
 
 API docs are configurable from `assegai.json`.
 
-If you want the runtime routes available, keep `enabled` set to `true`:
+Runtime documentation is disabled by default. If you want the runtime routes available, explicitly set `enabled` to `true`:
 
 ```json
 {
@@ -63,7 +63,7 @@ If you want the runtime routes available, keep `enabled` set to `true`:
 }
 ```
 
-If a project does not need runtime docs at all, disable them:
+If a project does not need runtime docs, omit the setting or disable it explicitly:
 
 ```json
 {
@@ -77,6 +77,8 @@ That turns off both:
 
 - `/docs`
 - `/openapi.json`
+
+The runtime documentation endpoints pass through the application's configured middleware. Protect them with the same authentication and authorization middleware as other non-public routes when they are enabled outside local development.
 
 The export commands are separate on purpose:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -42,6 +42,8 @@ $strategy = new SessionAuthStrategy([
 
 If authentication succeeds, the strategy stores a sanitized copy of the user in `$_SESSION`.
 
+Framework session cookies default to `HttpOnly` and `SameSite=Lax`; `Secure` is enabled automatically for HTTPS requests. Long-lived runtimes also isolate the session identifier and `$_SESSION` data between requests.
+
 ## JWT authentication
 
 Use JWT authentication when the client is calling your API directly and you want to return a token.

--- a/docs/controllers-and-routing.md
+++ b/docs/controllers-and-routing.md
@@ -413,6 +413,8 @@ public function upload(#[UploadedFile] object $file): array
 
 Under the hood this is driven by `Request::getFile()`, which is populated during multipart form handling.
 
+Treat the browser-supplied filename and MIME type as untrusted. `FileInterceptor` normalizes the original name, derives MIME data from the temporary file, enforces configured size and filter rules, and generates a random server-side storage name.
+
 ### Access to the raw request and response
 
 You do not always need the lower-level objects, but they are available:
@@ -516,12 +518,19 @@ In practice that means:
 
 ### Proxy-aware host resolution
 
-Request host matching is normalized from the incoming request metadata. The current `Request` implementation prefers:
+Request host matching is normalized from the incoming request metadata. By default, Assegai ignores forwarded host and scheme headers and uses the direct `Host` metadata. This prevents clients from selecting host-bound routes by supplying an untrusted `X-Forwarded-Host` value.
 
-1. `X-Forwarded-Host`
-2. `Host`
-3. `SERVER_NAME`
-4. `REMOTE_HOST`
+When the application is behind a known reverse proxy, list its exact IP addresses or CIDR ranges in `config/default.php`:
+
+```php
+<?php
+
+return [
+  'trustedProxies' => ['127.0.0.1', '10.0.0.0/8'],
+];
+```
+
+`TRUSTED_PROXIES` may also be supplied as a comma-separated environment value. Only requests whose `REMOTE_ADDR` matches that allowlist may use `X-Forwarded-Host` or `X-Forwarded-Proto`.
 
 Ports are stripped and hostnames are normalized to lowercase before matching.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,9 +109,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
   exit();
 }
 
-if (!isset($_GET['path']) || $_GET['path'] === '') {
-  $_GET['path'] = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
-}
+$_GET['path'] = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
 
 require_once __DIR__ . '/bootstrap.php';
 ```

--- a/docs/openswoole-runtime.md
+++ b/docs/openswoole-runtime.md
@@ -42,7 +42,7 @@ The current OpenSwoole settings live under:
         "workerNum": 1,
         "taskWorkerNum": 0,
         "maxRequest": 0,
-        "enableCoroutine": true,
+        "enableCoroutine": false,
         "hookFlags": "all"
       }
     }
@@ -59,6 +59,8 @@ Assegai translates those into the OpenSwoole server options it knows about today
 - `hookFlags` -> `hook_flags`
 
 Assegai validates these settings before the runtime boots. That means unsupported keys and invalid values fail early instead of being silently ignored.
+
+Coroutine request handling is intentionally disabled. PHP superglobals and session state are process-global, so Assegai rejects `enableCoroutine: true` until that state can be isolated safely between concurrent requests.
 
 `hookFlags` supports a few forms:
 

--- a/docs/serving-with-openswoole.md
+++ b/docs/serving-with-openswoole.md
@@ -62,7 +62,7 @@ If a project should usually boot with OpenSwoole, keep that in config:
         "workerNum": 1,
         "taskWorkerNum": 0,
         "maxRequest": 0,
-        "enableCoroutine": true,
+        "enableCoroutine": false,
         "hookFlags": "all"
       }
     }
@@ -83,7 +83,7 @@ Assegai validates these settings before the runtime boots, so a typo like `worke
 - `workerNum` controls how many HTTP workers the server starts
 - `taskWorkerNum` reserves task workers for short internal offloading work
 - `maxRequest` lets a worker restart after a fixed number of requests
-- `enableCoroutine` turns coroutine support on or off
+- `enableCoroutine` must remain `false`; Assegai rejects coroutine request handling until PHP global request and session state can be isolated safely
 - `hookFlags` controls which coroutine hooks OpenSwoole enables
 
 `hookFlags` can be:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,11 +51,6 @@ parameters:
 			path: src/App.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function set_error_handler expects \\(callable\\(int, string, string, int\\)\\: bool\\)\\|null, Closure\\(mixed, mixed, mixed, mixed\\)\\: void given\\.$#"
-			count: 1
-			path: src/App.php
-
-		-
 			message: "#^Parameter \\#1 \\$logger of class Assegai\\\\Core\\\\Exceptions\\\\Handlers\\\\HttpExceptionHandler constructor expects Psr\\\\Log\\\\LoggerInterface, Psr\\\\Log\\\\LoggerInterface\\|null given\\.$#"
 			count: 1
 			path: src/App.php
@@ -623,11 +618,6 @@ parameters:
 			path: src/Http/Requests/Request.php
 
 		-
-			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#"
-			count: 1
-			path: src/Http/Requests/Request.php
-
-		-
 			message: "#^Property Assegai\\\\Core\\\\Http\\\\Requests\\\\Request\\:\\:\\$allHeaders type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Http/Requests/Request.php
@@ -649,21 +639,6 @@ parameters:
 
 		-
 			message: "#^Property Assegai\\\\Core\\\\Http\\\\Requests\\\\Request\\:\\:\\$params type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Http/Requests/Request.php
-
-		-
-			message: "#^Property Assegai\\\\Core\\\\Http\\\\Requests\\\\Request\\:\\:\\$path \\(string\\) does not accept string\\|null\\.$#"
-			count: 1
-			path: src/Http/Requests/Request.php
-
-		-
-			message: "#^Variable \\$host might not be defined\\.$#"
-			count: 1
-			path: src/Http/Requests/Request.php
-
-		-
-			message: "#^Variable \\$path might not be defined\\.$#"
 			count: 1
 			path: src/Http/Requests/Request.php
 
@@ -971,11 +946,6 @@ parameters:
 			message: "#^Property Assegai\\\\Core\\\\Injector\\:\\:\\$reflectionClassCache with generic class ReflectionClass does not specify its types\\: T$#"
 			count: 1
 			path: src/Injector.php
-
-		-
-			message: "#^Method Assegai\\\\Core\\\\Interceptors\\\\FileInterceptorOptions\\:\\:__construct\\(\\) has parameter \\$limits with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Interceptors/FileInterceptorOptions.php
 
 		-
 			message: "#^Call to an undefined method ReflectionType\\:\\:getName\\(\\)\\.$#"

--- a/src/App.php
+++ b/src/App.php
@@ -13,6 +13,7 @@ use Assegai\Core\Enumerations\Http\ContentType;
 use Assegai\Core\Events\Event;
 use Assegai\Core\Exceptions\Container\ContainerException;
 use Assegai\Core\Exceptions\Container\EntryNotFoundException;
+use Assegai\Core\Exceptions\Handlers\DefaultErrorHandler;
 use Assegai\Core\Exceptions\Handlers\HttpExceptionHandler;
 use Assegai\Core\Exceptions\Handlers\WhoopsErrorHandler;
 use Assegai\Core\Exceptions\Handlers\WhoopsExceptionHandler;
@@ -117,6 +118,10 @@ class App implements AppInterface
      */
     protected ErrorHandlerInterface $errorHandler;
     /**
+     * @var ErrorHandlerInterface $productionErrorHandler The production-safe error handler.
+     */
+    protected ErrorHandlerInterface $productionErrorHandler;
+    /**
      * @var ExceptionHandlerInterface $exceptionHandler The exception handler.
      */
     protected ExceptionHandlerInterface $exceptionHandler;
@@ -162,6 +167,7 @@ class App implements AppInterface
     protected array $profileResults = [];
     protected int $profilePrecision = 4;
     protected bool $sessionStartedForRequest = false;
+    protected ?string $pendingSessionCookieHeader = null;
     protected bool $applicationGraphPrepared = false;
     protected bool $middlewarePrepared = false;
     protected bool $moduleInitInvoked = false;
@@ -214,6 +220,7 @@ class App implements AppInterface
         $this->setLogger(new ConsoleLogger(new ConsoleOutput()));
         $this->exceptionHandler = new WhoopsExceptionHandler($this->logger);
         $this->errorHandler = new WhoopsErrorHandler($this->logger);
+        $this->productionErrorHandler = new DefaultErrorHandler($this->logger);
         $this->httpExceptionHandler = new HttpExceptionHandler($this->logger);
 
         set_exception_handler(function (Throwable $exception) {
@@ -230,9 +237,23 @@ class App implements AppInterface
             }
         });
 
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            $this->errorHandler->handle($errno, $errstr, $errfile, $errline);
+        set_error_handler(function ($errno, $errstr, $errfile, $errline): bool {
+            return $this->handlePhpError($errno, $errstr, $errfile, $errline);
         });
+    }
+
+    /**
+     * Handles PHP runtime errors through the appropriate environment-specific handler.
+     */
+    protected function handlePhpError(int $errno, string $errstr, string $errfile, int $errline): bool
+    {
+        if (Environment::isProduction()) {
+            $this->productionErrorHandler->handle($errno, $errstr, $errfile, $errline);
+            return true;
+        }
+
+        $this->errorHandler->handle($errno, $errstr, $errfile, $errline);
+        return true;
     }
 
     /**
@@ -278,7 +299,7 @@ class App implements AppInterface
         $this->registerApplicationDependencies();
         $this->refreshRequestScope();
 
-        $this->isDebug = env('DEBUG_MODE', false);
+        $this->isDebug = Config::isDebug();
         $this->withProfiling = env('PROFILING', false);
     }
 
@@ -365,6 +386,7 @@ class App implements AppInterface
         $this->registerRequestScopedDependencies();
         $this->responder->setEmitter($this->getActiveResponseEmitter());
         $this->sessionStartedForRequest = false;
+        $this->pendingSessionCookieHeader = null;
     }
 
     /**
@@ -376,11 +398,15 @@ class App implements AppInterface
     {
         if (session_status() !== PHP_SESSION_ACTIVE) {
             $this->sessionStartedForRequest = false;
+            $this->applyPendingSessionCookieHeader();
+            $this->clearLongLivedRuntimeSessionState();
             return;
         }
 
         session_write_close();
         $this->sessionStartedForRequest = false;
+        $this->applyPendingSessionCookieHeader();
+        $this->clearLongLivedRuntimeSessionState();
     }
 
     /**
@@ -673,13 +699,13 @@ class App implements AppInterface
                     $this->profileResults['Application Graph Preparation'] = microtime(true) - $time;
                     $time = microtime(true);
                 }
-                if ($this->handleGeneratedApiDocsRequest()) {
-                    return;
-                }
                 $this->prepareMiddlewareGraph();
                 if ($this->withProfiling) {
                     $this->profileResults['Middleware Preparation'] = microtime(true) - $time;
                     $time = microtime(true);
+                }
+                if ($this->handleGeneratedApiDocsRequest()) {
+                    return;
                 }
                 $this->handleRequest();
             }
@@ -955,10 +981,159 @@ class App implements AppInterface
         session_cache_limiter($sessionLimiter);
         session_cache_expire($sessionExpire);
 
-        if (session_start()) {
+        $cookieParams = $this->resolveSessionCookieParameters();
+        ini_set('session.use_cookies', '1');
+        ini_set('session.use_only_cookies', '1');
+        session_set_cookie_params($cookieParams);
+        ini_set('session.use_strict_mode', '1');
+
+        $isLongLivedRuntime = $this->isLongLivedRuntime();
+        $incomingSessionId = null;
+
+        if ($isLongLivedRuntime) {
+            $incomingSessionId = $this->resolveIncomingSessionId();
+            session_id($incomingSessionId ?? '');
+        }
+
+        $sessionOptions = $isLongLivedRuntime
+            ? ['use_cookies' => false]
+            : [];
+
+        if (session_start($sessionOptions)) {
             $this->sessionStartedForRequest = true;
+            $currentSessionId = session_id();
+
+            if (
+                $isLongLivedRuntime &&
+                is_string($currentSessionId) &&
+                $currentSessionId !== '' &&
+                !hash_equals($incomingSessionId ?? '', $currentSessionId)
+            ) {
+                $this->pendingSessionCookieHeader = $this->buildSessionCookieHeader($currentSessionId, $cookieParams);
+            }
+
             broadcast(EventChannel::SESSION_START, new Event());
         }
+    }
+
+    private function isLongLivedRuntime(): bool
+    {
+        return strtolower($this->runtime->getName()) !== 'php';
+    }
+
+    private function applyPendingSessionCookieHeader(): void
+    {
+        if ($this->pendingSessionCookieHeader === null || !isset($this->response)) {
+            return;
+        }
+
+        $this->response->setHeader('Set-Cookie', $this->pendingSessionCookieHeader, false);
+        $this->pendingSessionCookieHeader = null;
+    }
+
+    private function clearLongLivedRuntimeSessionState(): void
+    {
+        if (!$this->isLongLivedRuntime()) {
+            return;
+        }
+
+        $_SESSION = [];
+
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_id('');
+            ini_set('session.use_cookies', '1');
+            ini_set('session.use_only_cookies', '1');
+        }
+    }
+
+    private function resolveIncomingSessionId(): ?string
+    {
+        $sessionName = session_name();
+
+        if (!is_string($sessionName)) {
+            return null;
+        }
+
+        $sessionId = $this->request->getCookies($sessionName);
+
+        if (!is_string($sessionId) || !preg_match('/^[A-Za-z0-9,-]{1,128}$/D', $sessionId)) {
+            return null;
+        }
+
+        return $sessionId;
+    }
+
+    /**
+     * @return array{lifetime: int, path: string, domain: string, secure: bool, httponly: bool, samesite: string}
+     */
+    private function resolveSessionCookieParameters(): array
+    {
+        $sessionConfig = $this->appConfig?->get('session', []);
+        $sessionConfig = is_array($sessionConfig) ? $sessionConfig : [];
+        $configuredSecure = $sessionConfig['cookieSecure'] ?? $sessionConfig['cookie_secure'] ?? null;
+        $sameSite = ucfirst(strtolower((string)($sessionConfig['cookieSameSite'] ?? $sessionConfig['cookie_samesite'] ?? 'Lax')));
+
+        if (!in_array($sameSite, ['Lax', 'Strict', 'None'], true)) {
+            $sameSite = 'Lax';
+        }
+
+        $secure = is_bool($configuredSecure)
+            ? $configuredSecure
+            : $this->request->getProtocol() === 'https';
+
+        if ($sameSite === 'None') {
+            $secure = true;
+        }
+
+        $path = (string)($sessionConfig['cookiePath'] ?? $sessionConfig['cookie_path'] ?? '/');
+        $domain = (string)($sessionConfig['cookieDomain'] ?? $sessionConfig['cookie_domain'] ?? '');
+
+        if ($path === '' || $path[0] !== '/' || preg_match('/[\x00-\x20;,\x7f]/', $path)) {
+            $path = '/';
+        }
+
+        if ($domain !== '' && !preg_match('/^\.?[a-z0-9.-]+$/iD', $domain)) {
+            $domain = '';
+        }
+
+        return [
+            'lifetime' => max(0, (int)($sessionConfig['cookieLifetime'] ?? $sessionConfig['cookie_lifetime'] ?? 0)),
+            'path' => $path,
+            'domain' => $domain,
+            'secure' => $secure,
+            'httponly' => (bool)($sessionConfig['cookieHttpOnly'] ?? $sessionConfig['cookie_httponly'] ?? true),
+            'samesite' => $sameSite,
+        ];
+    }
+
+    /**
+     * @param array{lifetime: int, path: string, domain: string, secure: bool, httponly: bool, samesite: string} $parameters
+     */
+    private function buildSessionCookieHeader(string $sessionId, array $parameters): string
+    {
+        $parts = [session_name() . '=' . rawurlencode($sessionId)];
+        $parts[] = 'Path=' . ($parameters['path'] !== '' ? $parameters['path'] : '/');
+
+        if ($parameters['domain'] !== '') {
+            $parts[] = 'Domain=' . $parameters['domain'];
+        }
+
+        if ($parameters['lifetime'] > 0) {
+            $parts[] = 'Max-Age=' . $parameters['lifetime'];
+            $parts[] = 'Expires=' . gmdate('D, d M Y H:i:s T', time() + $parameters['lifetime']);
+        }
+
+        if ($parameters['secure']) {
+            $parts[] = 'Secure';
+        }
+
+        if ($parameters['httponly']) {
+            $parts[] = 'HttpOnly';
+        }
+
+        $parts[] = 'SameSite=' . $parameters['samesite'];
+
+        return implode('; ', $parts);
     }
 
     /**
@@ -1232,7 +1407,7 @@ class App implements AppInterface
     {
         $requestPath = trim($this->request->getPath(), '/');
 
-        if ($this->projectConfig?->get('apiDocs.enabled', true) === false) {
+        if ($this->projectConfig?->get('apiDocs.enabled', false) !== true) {
             return false;
         }
 
@@ -1240,25 +1415,26 @@ class App implements AppInterface
             return false;
         }
 
-        $document = $this->describeApi();
         $response = $this->response;
         $response->reset();
+        $this->router->runMiddleware($this->request, $response, function () use ($requestPath, $response): void {
+            $document = $this->describeApi();
 
-        if ($requestPath === 'openapi.json') {
-            $response->jsonRaw($document);
-            $this->closeSessionForCurrentRequest();
-            $this->responder->respond($response);
-            return true;
-        }
+            if ($requestPath === 'openapi.json') {
+                $response->jsonRaw($document);
+                return;
+            }
 
-        $renderer = new SwaggerUiRenderer();
-        $response->setContentType(ContentType::HTML);
-        $response->setBody(
-            $renderer->render(
-                specUrl: '/openapi.json',
-                title: ($document['info']['title'] ?? 'Assegai API') . ' Docs',
-            )
-        );
+            $renderer = new SwaggerUiRenderer();
+            $response->setContentType(ContentType::HTML);
+            $response->setBody(
+                $renderer->render(
+                    specUrl: '/openapi.json',
+                    title: ($document['info']['title'] ?? 'Assegai API') . ' Docs',
+                )
+            );
+        });
+
         $this->closeSessionForCurrentRequest();
         $this->responder->respond($response);
         return true;

--- a/src/App.php
+++ b/src/App.php
@@ -396,6 +396,8 @@ class App implements AppInterface
      */
     protected function closeSessionForCurrentRequest(): void
     {
+        $this->prepareLongLivedRuntimeSessionCookie();
+
         if (session_status() !== PHP_SESSION_ACTIVE) {
             $this->sessionStartedForRequest = false;
             $this->applyPendingSessionCookieHeader();
@@ -1001,17 +1003,6 @@ class App implements AppInterface
 
         if (session_start($sessionOptions)) {
             $this->sessionStartedForRequest = true;
-            $currentSessionId = session_id();
-
-            if (
-                $isLongLivedRuntime &&
-                is_string($currentSessionId) &&
-                $currentSessionId !== '' &&
-                !hash_equals($incomingSessionId ?? '', $currentSessionId)
-            ) {
-                $this->pendingSessionCookieHeader = $this->buildSessionCookieHeader($currentSessionId, $cookieParams);
-            }
-
             broadcast(EventChannel::SESSION_START, new Event());
         }
     }
@@ -1019,6 +1010,28 @@ class App implements AppInterface
     private function isLongLivedRuntime(): bool
     {
         return strtolower($this->runtime->getName()) !== 'php';
+    }
+
+    private function prepareLongLivedRuntimeSessionCookie(): void
+    {
+        if (!$this->sessionStartedForRequest || !$this->isLongLivedRuntime()) {
+            return;
+        }
+
+        $currentSessionId = session_id();
+
+        if (
+            !is_string($currentSessionId) ||
+            $currentSessionId === '' ||
+            hash_equals($this->resolveIncomingSessionId() ?? '', $currentSessionId)
+        ) {
+            return;
+        }
+
+        $this->pendingSessionCookieHeader = $this->buildSessionCookieHeader(
+            $currentSessionId,
+            $this->resolveSessionCookieParameters()
+        );
     }
 
     private function applyPendingSessionCookieHeader(): void

--- a/src/Config.php
+++ b/src/Config.php
@@ -160,7 +160,7 @@ class Config
   public static function environment(): EnvironmentType|false
   {
     $env = self::normalizeEnvironmentValue(
-      self::readEnvironmentValue('ENV') ?? self::readEnvironmentValue('APP_ENV')
+      self::environmentValue('ENV') ?? self::environmentValue('APP_ENV')
     );
 
     return match ($env) {
@@ -268,12 +268,15 @@ class Config
   public static function isDebug(): bool
   {
     return filter_var(
-      self::readEnvironmentValue('DEBUG_MODE') ?? self::readEnvironmentValue('APP_DEBUG') ?? false,
+      self::environmentValue('DEBUG_MODE') ?? self::environmentValue('APP_DEBUG') ?? false,
       FILTER_VALIDATE_BOOL
     );
   }
 
-  private static function readEnvironmentValue(string $name): mixed
+  /**
+   * Reads an environment value from PHP's supported environment sources.
+   */
+  public static function environmentValue(string $name): mixed
   {
     if (array_key_exists($name, $_ENV)) {
       return $_ENV[$name];

--- a/src/Config.php
+++ b/src/Config.php
@@ -159,14 +159,17 @@ class Config
    */
   public static function environment(): EnvironmentType|false
   {
-    $env = $_ENV['ENV'] ?? null;
+    $env = self::normalizeEnvironmentValue(
+      self::readEnvironmentValue('ENV') ?? self::readEnvironmentValue('APP_ENV')
+    );
+
     return match ($env) {
-      'PROD' => EnvironmentType::PRODUCTION,
-      'STAGING' => EnvironmentType::STAGING,
+      'PROD', 'PRODUCTION' => EnvironmentType::PRODUCTION,
+      'STAGING', 'STAGE' => EnvironmentType::STAGING,
       'LOCAL' => EnvironmentType::LOCAL,
       'QA' => EnvironmentType::QA,
-      'DEV' => EnvironmentType::DEVELOP,
-      'TEST' => EnvironmentType::TEST,
+      'DEV', 'DEVELOP', 'DEVELOPMENT' => EnvironmentType::DEVELOP,
+      'TEST', 'TESTING' => EnvironmentType::TEST,
       default => false
     };
   }
@@ -264,6 +267,36 @@ class Config
    */
   public static function isDebug(): bool
   {
-    return filter_var(($_ENV['DEBUG_MODE'] ?? false), FILTER_VALIDATE_BOOL);
+    return filter_var(
+      self::readEnvironmentValue('DEBUG_MODE') ?? self::readEnvironmentValue('APP_DEBUG') ?? false,
+      FILTER_VALIDATE_BOOL
+    );
+  }
+
+  private static function readEnvironmentValue(string $name): mixed
+  {
+    if (array_key_exists($name, $_ENV)) {
+      return $_ENV[$name];
+    }
+
+    if (array_key_exists($name, $_SERVER)) {
+      return $_SERVER[$name];
+    }
+
+    $value = getenv($name);
+
+    return $value === false ? null : $value;
+  }
+
+  private static function normalizeEnvironmentValue(mixed $value): ?string
+  {
+    if (!is_scalar($value)) {
+      return null;
+    }
+
+    $normalized = trim((string)$value);
+    $normalized = preg_replace('/\s+#.*$/', '', $normalized) ?? $normalized;
+
+    return strtoupper(trim($normalized));
   }
 }

--- a/src/Config/ProjectConfig.php
+++ b/src/Config/ProjectConfig.php
@@ -3,6 +3,7 @@
 namespace Assegai\Core\Config;
 
 use Assegai\Core\Attributes\Injectable;
+use Assegai\Core\Config as RootConfig;
 use Assegai\Core\Enumerations\Http\ContextType;
 use Assegai\Core\Interfaces\ConfigInterface;
 use Assegai\Util\Path;
@@ -30,11 +31,11 @@ class ProjectConfig extends AbstractConfig
       $dotenv->safeLoad();
     }
 
-    if (!isset($_ENV['ENV'])) {
+    if (RootConfig::environmentValue('ENV') === null && RootConfig::environmentValue('APP_ENV') === null) {
       $_ENV['ENV'] = 'prod';
     }
 
-    if (!isset($_ENV['DEBUG_MODE'])) {
+    if (RootConfig::environmentValue('DEBUG_MODE') === null && RootConfig::environmentValue('APP_DEBUG') === null) {
       $_ENV['DEBUG_MODE'] = false;
     }
 

--- a/src/Environment.php
+++ b/src/Environment.php
@@ -25,7 +25,7 @@ class Environment
    */
   public static function isDebug(): bool
   {
-    return filter_var(($_ENV['DEBUG_MODE'] ?? false), FILTER_VALIDATE_BOOL);
+    return Config::isDebug();
   }
 
   /**

--- a/src/Http/Requests/Request.php
+++ b/src/Http/Requests/Request.php
@@ -130,21 +130,27 @@ class Request implements RequestInterface
         $this->fileData = $context->files;
         $this->rawBody = $context->rawBody;
 
-        $requestUri = (string)($this->serverData['REQUEST_URI'] ?? '/');
-        $this->uri = (string)($this->queryData['path'] ?? $requestUri);
+        $hasRequestUri = array_key_exists('REQUEST_URI', $this->serverData)
+            && is_scalar($this->serverData['REQUEST_URI']);
+        $requestUri = $hasRequestUri
+            ? (string)$this->serverData['REQUEST_URI']
+            : (string)($this->queryData['path'] ?? '/');
+        $this->uri = $requestUri !== '' ? $requestUri : '/';
         $parsedUrl = parse_url($this->uri);
 
-        $scheme = null;
-        $host = null;
-        $path = null;
+        $scheme = is_array($parsedUrl) && is_string($parsedUrl['scheme'] ?? null)
+            ? $parsedUrl['scheme']
+            : null;
+        $host = is_array($parsedUrl) && is_string($parsedUrl['host'] ?? null)
+            ? $parsedUrl['host']
+            : null;
+        $path = is_array($parsedUrl) && is_string($parsedUrl['path'] ?? null)
+            ? $parsedUrl['path']
+            : null;
 
-        if (is_array($parsedUrl)) {
-            extract($parsedUrl);
-        }
-
-        $this->scheme = $scheme ?? ((string)($this->serverData['REQUEST_SCHEME'] ?? 'http'));
+        $this->scheme = $this->resolveScheme($scheme);
         $this->host = $this->resolveHostName($host);
-        $this->path = $path;
+        $this->path = is_string($path) && $path !== '' ? $path : '/';
         $queryData = $this->queryData;
         unset($queryData['path']);
         $this->query = new RequestQuery((string)($this->serverData['QUERY_STRING'] ?? ''), $queryData);
@@ -188,10 +194,12 @@ class Request implements RequestInterface
     private function resolveHostName(?string $host = null): string
     {
         $candidates = [
-            $host,
-            $this->serverData['HTTP_X_FORWARDED_HOST'] ?? null,
+            $this->shouldTrustForwardedHeaders()
+                ? ($this->serverData['HTTP_X_FORWARDED_HOST'] ?? null)
+                : null,
             $this->serverData['HTTP_HOST'] ?? null,
             $this->serverData['SERVER_NAME'] ?? null,
+            $host,
             $this->serverData['REMOTE_HOST'] ?? null,
             'localhost',
         ];
@@ -205,6 +213,109 @@ class Request implements RequestInterface
         }
 
         return 'localhost';
+    }
+
+    private function resolveScheme(?string $parsedScheme = null): string
+    {
+        if ($this->shouldTrustForwardedHeaders()) {
+            $forwardedScheme = $this->serverData['HTTP_X_FORWARDED_PROTO'] ?? null;
+
+            if (is_string($forwardedScheme) && trim($forwardedScheme) !== '') {
+                $candidate = strtolower(trim(explode(',', $forwardedScheme)[0]));
+
+                if (in_array($candidate, ['http', 'https'], true)) {
+                    return $candidate;
+                }
+            }
+        }
+
+        $https = $this->serverData['HTTPS'] ?? null;
+
+        if ($https === true || $https === 1 || (is_string($https) && !in_array(strtolower($https), ['', 'off', '0'], true))) {
+            return 'https';
+        }
+
+        $requestScheme = strtolower((string)($this->serverData['REQUEST_SCHEME'] ?? ''));
+
+        if (in_array($requestScheme, ['http', 'https'], true)) {
+            return $requestScheme;
+        }
+
+        return in_array(strtolower((string)$parsedScheme), ['http', 'https'], true)
+            ? strtolower((string)$parsedScheme)
+            : 'http';
+    }
+
+    private function shouldTrustForwardedHeaders(): bool
+    {
+        $remoteAddress = $this->serverData['REMOTE_ADDR'] ?? null;
+
+        if (!is_string($remoteAddress) || filter_var($remoteAddress, FILTER_VALIDATE_IP) === false) {
+            return false;
+        }
+
+        $configuredProxies = Config::get('trustedProxies') ?? Config::get('TRUSTED_PROXIES');
+
+        if (is_string($configuredProxies)) {
+            $configuredProxies = array_map('trim', explode(',', $configuredProxies));
+        }
+
+        if (!is_array($configuredProxies)) {
+            return false;
+        }
+
+        foreach ($configuredProxies as $configuredProxy) {
+            if (is_string($configuredProxy) && $this->ipMatchesRange($remoteAddress, trim($configuredProxy))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function ipMatchesRange(string $address, string $range): bool
+    {
+        if ($range === '') {
+            return false;
+        }
+
+        if (!str_contains($range, '/')) {
+            return hash_equals(strtolower($range), strtolower($address));
+        }
+
+        [$network, $prefix] = array_pad(explode('/', $range, 2), 2, null);
+        $addressBytes = inet_pton($address);
+        $networkBytes = is_string($network) ? inet_pton($network) : false;
+
+        if ($addressBytes === false || $networkBytes === false || strlen($addressBytes) !== strlen($networkBytes)) {
+            return false;
+        }
+
+        if (!is_string($prefix) || filter_var($prefix, FILTER_VALIDATE_INT) === false) {
+            return false;
+        }
+
+        $prefixLength = (int)$prefix;
+        $maximumPrefix = strlen($addressBytes) * 8;
+
+        if ($prefixLength < 0 || $prefixLength > $maximumPrefix) {
+            return false;
+        }
+
+        $wholeBytes = intdiv($prefixLength, 8);
+        $remainingBits = $prefixLength % 8;
+
+        if ($wholeBytes > 0 && substr($addressBytes, 0, $wholeBytes) !== substr($networkBytes, 0, $wholeBytes)) {
+            return false;
+        }
+
+        if ($remainingBits === 0) {
+            return true;
+        }
+
+        $mask = (0xff << (8 - $remainingBits)) & 0xff;
+
+        return (ord($addressBytes[$wholeBytes]) & $mask) === (ord($networkBytes[$wholeBytes]) & $mask);
     }
 
     /**

--- a/src/Http/Requests/Request.php
+++ b/src/Http/Requests/Request.php
@@ -254,7 +254,7 @@ class Request implements RequestInterface
             return false;
         }
 
-        $configuredProxies = Config::get('trustedProxies') ?? Config::get('TRUSTED_PROXIES');
+        $configuredProxies = Config::get('trustedProxies') ?? Config::environmentValue('TRUSTED_PROXIES');
 
         if (is_string($configuredProxies)) {
             $configuredProxies = array_map('trim', explode(',', $configuredProxies));

--- a/src/Interceptors/FileInterceptor.php
+++ b/src/Interceptors/FileInterceptor.php
@@ -3,8 +3,8 @@
 namespace Assegai\Core\Interceptors;
 
 use Assegai\Core\Attributes\Injectable;
+use Assegai\Core\Exceptions\Http\BadRequestException;
 use Assegai\Core\ExecutionContext;
-use Assegai\Core\Http\Requests\Request;
 use Assegai\Core\Interfaces\IAssegaiInterceptor;
 
 /**
@@ -38,12 +38,76 @@ readonly class FileInterceptor implements IAssegaiInterceptor
     }
 
     $request = $context->switchToHttp()->getRequest();
-    $requestBody = $request->getBody();
     $key = $this->fieldName;
-    $file = $requestBody->$key;
-    $file['target_dir'] = $options->dest;
-    $file['target_path'] = $options->dest . '/' . $file['name'];
-    $file['extension'] = strtolower(pathinfo($file['target_path'], PATHINFO_EXTENSION));
+    $uploadedFiles = $request->getFile();
+    $candidate = is_array($uploadedFiles)
+      ? ($uploadedFiles[$key] ?? $uploadedFiles)
+      : ($uploadedFiles->$key ?? $uploadedFiles);
+
+    if (is_object($candidate)) {
+      $candidate = get_object_vars($candidate);
+    }
+
+    if (!is_array($candidate) || !isset($candidate['name'], $candidate['tmp_name'])) {
+      throw new BadRequestException("Missing uploaded file [$key].");
+    }
+
+    $error = (int)($candidate['error'] ?? UPLOAD_ERR_OK);
+
+    if ($error !== UPLOAD_ERR_OK) {
+      throw new BadRequestException("Upload [$key] failed with error code $error.");
+    }
+
+    $tmpName = (string)$candidate['tmp_name'];
+    $actualSize = $tmpName !== '' && is_file($tmpName) ? filesize($tmpName) : false;
+    $size = max(0, is_int($actualSize) ? $actualSize : (int)($candidate['size'] ?? 0));
+    $maxFileSize = $options->limits['fileSize'] ?? $options->limits['size'] ?? null;
+
+    if (is_numeric($maxFileSize) && $size > (int)$maxFileSize) {
+      throw new BadRequestException("Upload [$key] exceeds the configured file size limit.");
+    }
+
+    $originalName = str_replace('\\', '/', (string)$candidate['name']);
+    $safeName = basename($originalName);
+
+    if ($safeName === '' || $safeName === '.' || $safeName === '..' || str_starts_with($safeName, '.')) {
+      throw new BadRequestException("Upload [$key] has an unsafe filename.");
+    }
+
+    $extension = strtolower(pathinfo($safeName, PATHINFO_EXTENSION));
+
+    if (preg_match('/^(?:php\d*|phtml|phar|phps|inc|cgi|pl|py|rb|sh|bash|exe|com|bat|cmd|msi|htaccess)$/i', $extension)) {
+      throw new BadRequestException("Upload [$key] uses a prohibited executable extension.");
+    }
+
+    $detectedType = null;
+
+    if ($tmpName !== '' && is_file($tmpName)) {
+      $detectedType = mime_content_type($tmpName);
+    }
+
+    $storedName = bin2hex(random_bytes(16)) . ($extension !== '' ? ".{$extension}" : '');
+    $targetDirectory = rtrim($options->dest, "/\\");
+
+    if ($targetDirectory === '' || str_contains($targetDirectory, "\0")) {
+      throw new BadRequestException('The upload destination is invalid.');
+    }
+
+    $file = [
+      ...$candidate,
+      'name' => $safeName,
+      'original_name' => $safeName,
+      'stored_name' => $storedName,
+      'type' => is_string($detectedType) ? $detectedType : (string)($candidate['type'] ?? ''),
+      'size' => $size,
+      'target_dir' => $targetDirectory,
+      'target_path' => $targetDirectory . DIRECTORY_SEPARATOR . $storedName,
+      'extension' => $extension,
+    ];
+
+    if ($options->fileFilter && ($options->fileFilter)($file, $request) !== true) {
+      throw new BadRequestException("Upload [$key] was rejected by the configured file filter.");
+    }
 
     $request->setFile($file);
 

--- a/src/Interceptors/FileInterceptorOptions.php
+++ b/src/Interceptors/FileInterceptorOptions.php
@@ -6,6 +6,9 @@ use Closure;
 
 class FileInterceptorOptions
 {
+  /**
+   * @param array{fileSize?: int, size?: int} $limits
+   */
   public function __construct(
     public readonly string $dest = DEFAULT_STORAGE_PATH,
     public readonly string $storage = DEFAULT_STORAGE_PATH,

--- a/src/Rendering/DocumentProperties.php
+++ b/src/Rendering/DocumentProperties.php
@@ -257,7 +257,13 @@ class DocumentProperties
      */
     private function generateTitleTag(): string
     {
-        return $this->getIndent(2) . "<title>" . ($this->title ?: static::DEFAULT_TITLE) . "</title>" . PHP_EOL;
+        $title = htmlspecialchars(
+            $this->title ?: static::DEFAULT_TITLE,
+            ENT_QUOTES | ENT_SUBSTITUTE,
+            'UTF-8',
+        );
+
+        return $this->getIndent(2) . "<title>$title</title>" . PHP_EOL;
     }
 
     /**
@@ -297,7 +303,13 @@ class DocumentProperties
             $type = static::DEFAULT_FAVICON[1];
         }
 
-        return $this->getIndent(2) . "<link rel='shortcut icon' href='$href' type='$type' />" . PHP_EOL;
+        $attributes = $this->renderHtmlAttributes([
+            'rel' => 'shortcut icon',
+            'href' => (string)$href,
+            'type' => (string)$type,
+        ]);
+
+        return $this->getIndent(2) . "<link$attributes />" . PHP_EOL;
     }
 
     /**
@@ -393,7 +405,9 @@ class DocumentProperties
             return '';
         }
 
-        return $this->getIndent(2) . "<base href='$this->base' />" . PHP_EOL;
+        $attributes = $this->renderHtmlAttributes(['href' => $this->base]);
+
+        return $this->getIndent(2) . "<base$attributes />" . PHP_EOL;
     }
 
     /**

--- a/src/Rendering/Engines/DefaultTemplateEngine.php
+++ b/src/Rendering/Engines/DefaultTemplateEngine.php
@@ -246,6 +246,7 @@ class DefaultTemplateEngine extends TemplateEngine
         $rawDocumentProps = $this->meta['props'] ?? [];
         $documentProps = DocumentProperties::fromArray(is_array($rawDocumentProps) ? $rawDocumentProps : []);
         $lang = $this->getMetaString('lang') ?? ($documentProps->lang ?: Request::current()->getLang());
+        $lang = htmlspecialchars($lang, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         $headAssets = $documentProps->generateHeadAssetTags();
 
         if (is_string($rawDocumentProps) && trim($rawDocumentProps) !== '') {
@@ -256,7 +257,11 @@ class DefaultTemplateEngine extends TemplateEngine
         $headAssets .= $this->loadStyles();
         $headAssets .= $this->loadScripts();
         $output = $template->render([...$this->data]);
-        $charSet = $this->meta['charset'] ?? 'UTF-8';
+        $charSet = htmlspecialchars(
+            (string)($this->meta['charset'] ?? 'UTF-8'),
+            ENT_QUOTES | ENT_SUBSTITUTE,
+            'UTF-8',
+        );
         $documentMetaTags = $this->renderDocumentMetaTags();
         $bodyScripts = $documentProps->generateBodyScriptTags() . $documentProps->generateBodyScriptImportTags();
         $webComponentBundleTag = $this->loadWebComponentBundle();

--- a/src/Rendering/Engines/ViewEngine.php
+++ b/src/Rendering/Engines/ViewEngine.php
@@ -83,7 +83,7 @@ final class ViewEngine
     if (!$this->view) {
       throw new RenderingException("Invalid view");
     }
-    $lang = $this->view->props->lang;
+    $lang = htmlspecialchars($this->view->props->lang, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 
     $html = <<<START
 <!DOCTYPE html>

--- a/src/Rendering/ViewMeta.php
+++ b/src/Rendering/ViewMeta.php
@@ -57,7 +57,9 @@ class ViewMeta
     $html = '';
     foreach ($this->httpEquiv as $name => $content)
     {
-      $html .= "<meta http-equiv='$name' content='$content' />" . PHP_EOL;
+      $escapedName = htmlspecialchars((string)$name, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+      $escapedContent = htmlspecialchars((string)$content, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+      $html .= "<meta http-equiv='$escapedName' content='$escapedContent' />" . PHP_EOL;
     }
     return $html;
   }
@@ -69,7 +71,9 @@ class ViewMeta
   {    $html = '';
     foreach ($this->props as $name => $content)
     {
-      $html .= "<meta name='$name' content='$content'>" . PHP_EOL;
+      $escapedName = htmlspecialchars((string)$name, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+      $escapedContent = htmlspecialchars((string)$content, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+      $html .= "<meta name='$escapedName' content='$escapedContent'>" . PHP_EOL;
     }
     return $html;
   }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -1413,7 +1413,7 @@ final class Router
      * @throws ReflectionException
      * @throws HttpException
      */
-    private function runMiddleware(Request $request, Response $response, callable $next): bool
+    public function runMiddleware(Request $request, Response $response, callable $next): bool
     {
         if (!$this->middlewareConsumer) {
             $next();

--- a/src/Runtimes/OpenSwoole/OpenSwooleServerSettingsResolver.php
+++ b/src/Runtimes/OpenSwoole/OpenSwooleServerSettingsResolver.php
@@ -73,7 +73,7 @@ final class OpenSwooleServerSettingsResolver
   {
     $normalized = $this->normalize($settings);
     $serverSettings = [
-      'enable_coroutine' => $normalized['enableCoroutine'] ?? true,
+      'enable_coroutine' => $normalized['enableCoroutine'] ?? false,
     ];
 
     if (array_key_exists('hookFlags', $normalized)) {

--- a/src/Runtimes/OpenSwooleHttpRuntime.php
+++ b/src/Runtimes/OpenSwooleHttpRuntime.php
@@ -32,6 +32,13 @@ class OpenSwooleHttpRuntime implements HttpRuntimeInterface
   {
     $this->assertNetworkBinding();
     $this->settings = (new OpenSwooleServerSettingsResolver())->normalize($settings);
+
+    if (($this->settings['enableCoroutine'] ?? false) === true) {
+      throw new InvalidArgumentException(
+        'OpenSwoole coroutine request handling is disabled until all process-global PHP state is coroutine-safe.'
+      );
+    }
+
     $this->serverFactory ??= new NativeOpenSwooleServerFactory();
   }
 
@@ -145,10 +152,10 @@ class OpenSwooleHttpRuntime implements HttpRuntimeInterface
     $normalizedServerData['CONTENT_TYPE'] = (string) ($headerData['content-type'] ?? '');
     $normalizedServerData['REMOTE_ADDR'] = (string) ($serverData['remote_addr'] ?? '127.0.0.1');
     $normalizedServerData['SERVER_PROTOCOL'] = (string) ($serverData['server_protocol'] ?? 'HTTP/1.1');
-    $normalizedServerData['REQUEST_SCHEME'] = (string) ($headerData['x-forwarded-proto'] ?? 'http');
+    $normalizedServerData['REQUEST_SCHEME'] = (string) ($serverData['request_scheme'] ?? 'http');
 
     $query = $request->get ?? [];
-    $query['path'] ??= $normalizedServerData['REQUEST_URI'];
+    $query['path'] = (string) (parse_url($normalizedServerData['REQUEST_URI'], PHP_URL_PATH) ?: '/');
 
     return new RuntimeRequestContext(
       server: $normalizedServerData,

--- a/tests/Unit.suite.yml
+++ b/tests/Unit.suite.yml
@@ -3,6 +3,7 @@
 # Suite for unit or integration tests.
 
 actor: UnitTester
+bootstrap: _bootstrap.php
 modules:
     enabled:
         - Asserts

--- a/tests/Unit/ApiDocsCest.php
+++ b/tests/Unit/ApiDocsCest.php
@@ -9,6 +9,7 @@ use Assegai\Core\ApiDocs\SwaggerUiRenderer;
 use Assegai\Core\ApiDocs\TypeScriptClientGenerator;
 use Assegai\Core\Config\ComposerConfig;
 use Assegai\Core\Config\ProjectConfig;
+use Assegai\Core\Consumers\MiddlewareConsumer;
 use Assegai\Core\ControllerManager;
 use Assegai\Core\Http\Requests\Request;
 use Assegai\Core\Http\Responses\Interfaces\ResponseEmitterInterface;
@@ -55,6 +56,9 @@ class ApiDocsCest
     ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     file_put_contents($this->workspace . '/assegai.json', json_encode([
       'name' => 'Test API',
+      'apiDocs' => [
+        'enabled' => true,
+      ],
     ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     file_put_contents($this->envFile, '');
     file_put_contents($this->defaultConfigFile, '<?php return [];');
@@ -305,6 +309,71 @@ class ApiDocsCest
     $I->assertTrue($handled);
     $I->assertCount(1, $capturingEmitter->emissions);
     $I->assertSame('3.1.0', json_decode($capturingEmitter->emissions[0]['body'], true)['openapi']);
+  }
+
+  public function testGeneratedApiDocsAreDisabledUnlessExplicitlyEnabled(UnitTester $I): void
+  {
+    file_put_contents($this->workspace . '/assegai.json', json_encode([
+      'name' => 'Test API',
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    $_SERVER['REQUEST_URI'] = '/openapi.json';
+    $_GET['path'] = 'openapi.json';
+
+    $app = AssegaiFactory::create(ApiDocsAppModule::class);
+    $refreshRequestScope = new \ReflectionMethod($app, 'refreshRequestScope');
+    $refreshRequestScope->invoke($app);
+
+    $handleGeneratedApiDocsRequest = new \ReflectionMethod($app, 'handleGeneratedApiDocsRequest');
+
+    $I->assertFalse($handleGeneratedApiDocsRequest->invoke($app));
+  }
+
+  public function testGeneratedApiDocsRunThroughConfiguredMiddleware(UnitTester $I): void
+  {
+    $_SERVER['REQUEST_URI'] = '/openapi.json';
+    $_GET['path'] = 'openapi.json';
+
+    $app = AssegaiFactory::create(ApiDocsAppModule::class);
+    $capturingEmitter = new class implements ResponseEmitterInterface {
+      /** @var array<int, array{body: string, response: ResponseInterface|null}> */
+      public array $emissions = [];
+
+      public function emit(string $body, ?ResponseInterface $response = null): void
+      {
+        $this->emissions[] = [
+          'body' => $body,
+          'response' => $response,
+        ];
+      }
+    };
+    $responder = Responder::current();
+    $responder->setEmitter($capturingEmitter);
+    $responderProperty = new ReflectionProperty($app, 'responder');
+    $responderProperty->setValue($app, $responder);
+
+    $refreshRequestScope = new \ReflectionMethod($app, 'refreshRequestScope');
+    $refreshRequestScope->invoke($app);
+    $responder->setEmitter($capturingEmitter);
+    $responderProperty->setValue($app, $responder);
+
+    $consumer = new MiddlewareConsumer();
+    $consumer->apply(
+      static function (Request $request, Response $response, callable $next): void {
+        $response->setStatus(403);
+        $response->jsonRaw(['error' => 'forbidden']);
+      }
+    )->forRoutes('openapi.json');
+
+    $routerProperty = new ReflectionProperty($app, 'router');
+    $routerProperty->getValue($app)->setMiddlewareConsumer($consumer);
+
+    $handleGeneratedApiDocsRequest = new \ReflectionMethod($app, 'handleGeneratedApiDocsRequest');
+    $handled = $handleGeneratedApiDocsRequest->invoke($app);
+
+    $I->assertTrue($handled);
+    $I->assertCount(1, $capturingEmitter->emissions);
+    $I->assertSame(['error' => 'forbidden'], json_decode($capturingEmitter->emissions[0]['body'], true));
+    $I->assertSame(403, $capturingEmitter->emissions[0]['response']?->getStatus()->code);
   }
 
   public function testCreateFromProjectKeepsApiDocsBoundToTheExplicitWorkspace(UnitTester $I): void

--- a/tests/Unit/ConfigCest.php
+++ b/tests/Unit/ConfigCest.php
@@ -4,6 +4,7 @@
 namespace Unit;
 
 use Assegai\Core\Config;
+use Assegai\Core\Config\ProjectConfig;
 use Assegai\Core\Enumerations\EnvironmentType;
 use Assegai\Core\Exceptions\ConfigurationException;
 use Assegai\Core\Util\Paths;
@@ -171,6 +172,25 @@ class ConfigCest
 
     $_ENV['ENV'] = 'DEV';
     unset($_ENV['APP_ENV']);
+  }
+
+  public function testProjectDefaultsDoNotShadowEnvironmentAliases(UnitTester $I): void
+  {
+    unset($_ENV['ENV'], $_ENV['DEBUG_MODE']);
+    unset($_SERVER['ENV'], $_SERVER['DEBUG_MODE']);
+    $_ENV['APP_ENV'] = 'development';
+    $_ENV['APP_DEBUG'] = 'true';
+
+    new class extends ProjectConfig {
+      public function load(): void
+      {
+      }
+    };
+
+    $I->assertArrayNotHasKey('ENV', $_ENV);
+    $I->assertArrayNotHasKey('DEBUG_MODE', $_ENV);
+    $I->assertSame(EnvironmentType::DEVELOP, Config::environment());
+    $I->assertTrue(Config::isDebug());
   }
 
   #[Skip]

--- a/tests/Unit/ConfigCest.php
+++ b/tests/Unit/ConfigCest.php
@@ -32,7 +32,8 @@ class ConfigCest
       unset($GLOBALS['config']);
     }
 
-    unset($_ENV['ENV'], $_ENV['DEBUG_MODE']);
+    unset($_ENV['ENV'], $_ENV['DEBUG_MODE'], $_ENV['APP_ENV'], $_ENV['APP_DEBUG']);
+    unset($_SERVER['ENV'], $_SERVER['DEBUG_MODE'], $_SERVER['APP_ENV'], $_SERVER['APP_DEBUG']);
 
     $I->assertFalse(isset($GLOBALS['config']));
     Config::hydrate($this->workingDirectory);
@@ -149,6 +150,29 @@ class ConfigCest
     $I->assertFalse($isProductionEnvironment);
   }
 
+  public function testEnvironmentMethodAcceptsCommonAliases(UnitTester $I): void
+  {
+    $_ENV['ENV'] = 'prod';
+    $I->assertSame(EnvironmentType::PRODUCTION, Config::environment());
+
+    $_ENV['ENV'] = 'PRODUCTION';
+    $I->assertSame(EnvironmentType::PRODUCTION, Config::environment());
+
+    $_ENV['ENV'] = 'DEV # inline comment';
+    $I->assertSame(EnvironmentType::DEVELOP, Config::environment());
+
+    unset($_ENV['ENV']);
+    unset($_SERVER['ENV']);
+    $_ENV['APP_ENV'] = 'production';
+    $I->assertSame(EnvironmentType::PRODUCTION, Config::environment());
+
+    $_ENV['APP_ENV'] = 'development';
+    $I->assertSame(EnvironmentType::DEVELOP, Config::environment());
+
+    $_ENV['ENV'] = 'DEV';
+    unset($_ENV['APP_ENV']);
+  }
+
   #[Skip]
   public function testTheSetEnvironmentMethod(UnitTester $I): void
   {
@@ -178,6 +202,14 @@ class ConfigCest
   /** @noinspection SpellCheckingInspection */
   public function testTheIsdebugMethods(UnitTester $I): void
   {
+    $I->assertFalse(Config::isDebug());
+
+    unset($_ENV['DEBUG_MODE']);
+    unset($_SERVER['DEBUG_MODE']);
+    $_ENV['APP_DEBUG'] = 'true';
+    $I->assertTrue(Config::isDebug());
+
+    $_ENV['APP_DEBUG'] = 'false';
     $I->assertFalse(Config::isDebug());
   }
 }

--- a/tests/Unit/ExceptionHandlersCest.php
+++ b/tests/Unit/ExceptionHandlersCest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Unit;
 
+use Assegai\Core\App;
 use Assegai\Core\Enumerations\Http\ContentType;
+use Assegai\Core\Exceptions\Handlers\DefaultErrorHandler;
 use Assegai\Core\Exceptions\Handlers\DefaultExceptionHandler;
 use Assegai\Core\Exceptions\Handlers\HttpExceptionHandler;
 use Assegai\Core\Exceptions\Handlers\Support\FrameworkErrorPageRenderer;
@@ -10,6 +12,7 @@ use Assegai\Core\Exceptions\Http\ForbiddenException;
 use Assegai\Core\Exceptions\Http\NotFoundException;
 use Assegai\Core\Exceptions\Handlers\WhoopsErrorHandler;
 use Assegai\Core\Exceptions\Handlers\WhoopsExceptionHandler;
+use Assegai\Core\Exceptions\Interfaces\ErrorHandlerInterface;
 use Assegai\Core\Http\Requests\Interfaces\RequestInterface;
 use Assegai\Core\Http\Requests\Request;
 use Assegai\Core\Http\Requests\RuntimeRequestContext;
@@ -18,6 +21,7 @@ use RuntimeException;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 use Tests\Support\UnitTester;
+use Throwable;
 
 class ExceptionHandlersCest
 {
@@ -127,6 +131,64 @@ class ExceptionHandlersCest
     $I->assertStringContainsString(RuntimeException::class, $records[0]['message']);
     $I->assertStringContainsString('Runtime failure', $records[0]['message']);
     $I->assertStringContainsString('Stack trace:', $records[0]['message']);
+  }
+
+  public function testAppRoutesPhpErrorsToProductionSafeHandler(UnitTester $I): void
+  {
+    $_ENV['ENV'] = 'PROD';
+
+    $developmentHandler = new class implements ErrorHandlerInterface {
+      public array $errors = [];
+
+      public function handle(int $errno, string $errstr, string $errfile, int $errline): void
+      {
+        $this->errors[] = compact('errno', 'errstr', 'errfile', 'errline');
+      }
+
+      public function handleError(Throwable $error): void
+      {
+        $this->errors[] = $error;
+      }
+    };
+
+    $productionHandler = new class implements ErrorHandlerInterface {
+      public array $errors = [];
+
+      public function handle(int $errno, string $errstr, string $errfile, int $errline): void
+      {
+        $this->errors[] = compact('errno', 'errstr', 'errfile', 'errline');
+      }
+
+      public function handleError(Throwable $error): void
+      {
+        $this->errors[] = $error;
+      }
+    };
+
+    $app = new class extends App {
+      public function __construct()
+      {
+      }
+
+      public function setErrorHandlersForTest(ErrorHandlerInterface $developmentHandler, ErrorHandlerInterface $productionHandler): void
+      {
+        $this->errorHandler = $developmentHandler;
+        $this->productionErrorHandler = $productionHandler;
+      }
+
+      public function handlePhpErrorForTest(int $errno, string $errstr, string $errfile, int $errline): bool
+      {
+        return $this->handlePhpError($errno, $errstr, $errfile, $errline);
+      }
+    };
+    $app->setErrorHandlersForTest($developmentHandler, $productionHandler);
+
+    $handled = $app->handlePhpErrorForTest(E_WARNING, 'Undefined array key 0', __FILE__, __LINE__);
+
+    $I->assertTrue($handled);
+    $I->assertCount(0, $developmentHandler->errors);
+    $I->assertCount(1, $productionHandler->errors);
+    $I->assertSame('Undefined array key 0', $productionHandler->errors[0]['errstr']);
   }
 
   public function testWhoopsExceptionHandlerAlsoChoosesJsonForNonGetRequests(UnitTester $I): void
@@ -355,6 +417,44 @@ class ExceptionHandlersCest
     $I->assertStringContainsString('Page not found', $html);
     $I->assertStringContainsString('404', $html);
     $I->assertStringContainsString('AssegaiPHP', $html);
+  }
+
+  public function testDefaultErrorHandlerHidesRuntimeWarningsInProduction(UnitTester $I): void
+  {
+    $_ENV['ENV'] = 'PROD';
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_SERVER['CONTENT_TYPE'] = '';
+    $_SERVER['HTTP_ACCEPT'] = 'text/html';
+
+    $logger = $this->createNullLogger();
+
+    $handler = new class($logger) extends DefaultErrorHandler {
+      public array $emissions = [];
+
+      public function __construct(LoggerInterface $logger)
+      {
+        parent::__construct($logger);
+      }
+
+      protected function emitErrorResponse(string $body, ContentType $contentType, int $statusCode): void
+      {
+        $this->emissions[] = [
+          'body' => $body,
+          'status' => $statusCode,
+          'content_type' => $contentType->value,
+        ];
+      }
+    };
+
+    $handler->handle(E_WARNING, 'Undefined array key 0', __FILE__, __LINE__);
+
+    $I->assertCount(1, $handler->emissions);
+    $I->assertSame(500, $handler->emissions[0]['status']);
+    $I->assertSame('text/html', $handler->emissions[0]['content_type']);
+    $I->assertStringContainsString('Internal server error', $handler->emissions[0]['body']);
+    $I->assertStringNotContainsString('Undefined array key 0', $handler->emissions[0]['body']);
+    $I->assertStringNotContainsString('ExceptionHandlersCest.php', $handler->emissions[0]['body']);
+    $I->assertStringNotContainsString('Details', $handler->emissions[0]['body']);
   }
 
   public function testDefaultExceptionHandlerCanRenderHtmlErrors(UnitTester $I): void

--- a/tests/Unit/RequestCest.php
+++ b/tests/Unit/RequestCest.php
@@ -24,6 +24,8 @@ class RequestCest
     $_POST = [];
     $_FILES = [];
     $_SERVER = [];
+    unset($_ENV['TRUSTED_PROXIES']);
+    putenv('TRUSTED_PROXIES');
   }
 
   public function testTheGetInstanceMethod(UnitTester $I): void
@@ -143,6 +145,20 @@ class RequestCest
     );
 
     $I->assertSame('tenant.example.com', $request->getHostName());
+  }
+
+  public function testTheRequestReadsTrustedProxiesFromTheProcessEnvironment(UnitTester $I): void
+  {
+    putenv('TRUSTED_PROXIES=127.0.0.1');
+    $request = $this->createRequest(
+      server: [
+        'HTTP_HOST' => 'tenant.example.com',
+        'HTTP_X_FORWARDED_HOST' => 'admin.example.com',
+        'REMOTE_ADDR' => '127.0.0.1',
+      ],
+    );
+
+    $I->assertSame('admin.example.com', $request->getHostName());
   }
 
   public function testTheRequestUriCannotBeOverriddenByAPathQueryParameter(UnitTester $I): void

--- a/tests/Unit/RequestCest.php
+++ b/tests/Unit/RequestCest.php
@@ -118,14 +118,45 @@ class RequestCest
 
   public function testTheRequestNormalizesForwardedHosts(UnitTester $I): void
   {
+    $_ENV['TRUSTED_PROXIES'] = '127.0.0.1';
     $request = $this->createRequest(
       server: [
         'HTTP_HOST' => 'tenant.example.com:8080',
         'HTTP_X_FORWARDED_HOST' => 'Admin.Example.com:8443, proxy.internal',
+        'REMOTE_ADDR' => '127.0.0.1',
       ],
     );
 
     $I->assertSame('admin.example.com', $request->getHostName());
+    unset($_ENV['TRUSTED_PROXIES']);
+  }
+
+  public function testTheRequestIgnoresForwardedHostsFromUntrustedClients(UnitTester $I): void
+  {
+    unset($_ENV['TRUSTED_PROXIES']);
+    $request = $this->createRequest(
+      server: [
+        'HTTP_HOST' => 'tenant.example.com:8080',
+        'HTTP_X_FORWARDED_HOST' => 'admin.example.com',
+        'REMOTE_ADDR' => '203.0.113.10',
+      ],
+    );
+
+    $I->assertSame('tenant.example.com', $request->getHostName());
+  }
+
+  public function testTheRequestUriCannotBeOverriddenByAPathQueryParameter(UnitTester $I): void
+  {
+    $request = $this->createRequest(
+      server: [
+        'REQUEST_URI' => '/public?path=/admin',
+      ],
+      get: [
+        'path' => '/admin',
+      ],
+    );
+
+    $I->assertSame('/public', $request->getPath());
   }
 
   private function createRequest(

--- a/tests/Unit/RouterCest.php
+++ b/tests/Unit/RouterCest.php
@@ -1005,6 +1005,7 @@ class RouterCest
     RuntimeContext::flush();
     $_GET['path'] = $path;
     $_SERVER['REQUEST_METHOD'] = $method;
+    $_SERVER['REQUEST_URI'] = $path;
     $_SERVER['HTTP_HOST'] = $host;
     $_SERVER['REMOTE_HOST'] = $host;
     unset($_SERVER['HTTP_X_FORWARDED_HOST']);

--- a/tests/Unit/RuntimeCest.php
+++ b/tests/Unit/RuntimeCest.php
@@ -37,6 +37,20 @@ class RuntimeProbeController
       'remote_ip' => $request->getRemoteIp(),
     ]);
   }
+
+  #[Get('session/write')]
+  public function writeSession(): Response
+  {
+    $_SESSION['principal'] = 'alice';
+
+    return Response::current()->jsonRaw(['stored' => 'alice']);
+  }
+
+  #[Get('session/read')]
+  public function readSession(): Response
+  {
+    return Response::current()->jsonRaw(['principal' => $_SESSION['principal'] ?? null]);
+  }
 }
 
 #[Module(controllers: [RuntimeProbeController::class])]
@@ -347,7 +361,7 @@ class RuntimeCest
             'workerNum' => 2,
             'taskWorkerNum' => 1,
             'maxRequest' => 250,
-            'enableCoroutine' => true,
+            'enableCoroutine' => false,
             'hookFlags' => 'all',
           ],
         ],
@@ -412,6 +426,12 @@ class RuntimeCest
     $I->expectThrowable(InvalidArgumentException::class, static function (): void {
       new OpenSwooleHttpRuntime(settings: [
         'workerNum' => 0,
+      ]);
+    });
+
+    $I->expectThrowable(InvalidArgumentException::class, static function (): void {
+      new OpenSwooleHttpRuntime(settings: [
+        'enableCoroutine' => true,
       ]);
     });
   }
@@ -714,7 +734,7 @@ class RuntimeCest
         'workerNum' => 2,
         'taskWorkerNum' => 1,
         'maxRequest' => 50,
-        'enableCoroutine' => true,
+        'enableCoroutine' => false,
         'hookFlags' => 'all',
       ],
       serverFactory: $factory,
@@ -726,7 +746,7 @@ class RuntimeCest
     $I->assertSame(2, $server->settings['worker_num'] ?? null);
     $I->assertSame(1, $server->settings['task_worker_num'] ?? null);
     $I->assertSame(50, $server->settings['max_request'] ?? null);
-    $I->assertTrue($server->settings['enable_coroutine'] ?? false);
+    $I->assertFalse($server->settings['enable_coroutine'] ?? true);
     $I->assertArrayHasKey('hook_flags', $server->settings);
     $I->assertSame(200, $response->status);
     $I->assertSame('application/json', $response->headers['Content-Type'] ?? null);
@@ -772,8 +792,22 @@ class RuntimeCest
         ],
         remoteAddress: '10.20.30.52',
       ),
+      $this->createFakeOpenSwooleRequest(
+        path: '/runtime-probe/session/write',
+        queryString: '',
+        query: [],
+        remoteAddress: '10.20.30.53',
+      ),
+      $this->createFakeOpenSwooleRequest(
+        path: '/runtime-probe/session/read',
+        queryString: '',
+        query: [],
+        remoteAddress: '10.20.30.54',
+      ),
     ];
     $responses = [
+      $this->createFakeOpenSwooleResponse(),
+      $this->createFakeOpenSwooleResponse(),
       $this->createFakeOpenSwooleResponse(),
       $this->createFakeOpenSwooleResponse(),
     ];
@@ -831,6 +865,8 @@ class RuntimeCest
 
     $firstPayload = json_decode($responses[0]->body, true);
     $secondPayload = json_decode($responses[1]->body, true);
+    $sessionWritePayload = json_decode($responses[2]->body, true);
+    $sessionReadPayload = json_decode($responses[3]->body, true);
 
     $I->assertSame(200, $responses[0]->status);
     $I->assertSame(200, $responses[1]->status);
@@ -850,6 +886,10 @@ class RuntimeCest
       'cookie' => 'second',
       'remote_ip' => '10.20.30.52',
     ], $secondPayload);
+    $I->assertSame(['stored' => 'alice'], $sessionWritePayload);
+    $I->assertSame(['principal' => null], $sessionReadPayload);
+    $I->assertStringContainsString('HttpOnly', $responses[2]->headers['Set-Cookie'] ?? '');
+    $I->assertStringContainsString('SameSite=Lax', $responses[2]->headers['Set-Cookie'] ?? '');
     $I->assertSame(1, $this->readProtectedProperty($app, 'applicationGraphBuildCount'));
     $I->assertSame(1, $this->readProtectedProperty($app, 'middlewareBuildCount'));
     $I->assertNull(RuntimeContext::get(Request::class));

--- a/tests/Unit/RuntimeCest.php
+++ b/tests/Unit/RuntimeCest.php
@@ -51,6 +51,18 @@ class RuntimeProbeController
   {
     return Response::current()->jsonRaw(['principal' => $_SESSION['principal'] ?? null]);
   }
+
+  #[Get('session/regenerate')]
+  public function regenerateSession(): Response
+  {
+    $previousSessionId = session_id();
+    session_regenerate_id(true);
+
+    return Response::current()->jsonRaw([
+      'previous' => $previousSessionId,
+      'current' => session_id(),
+    ]);
+  }
 }
 
 #[Module(controllers: [RuntimeProbeController::class])]
@@ -804,8 +816,15 @@ class RuntimeCest
         query: [],
         remoteAddress: '10.20.30.54',
       ),
+      $this->createFakeOpenSwooleRequest(
+        path: '/runtime-probe/session/regenerate',
+        queryString: '',
+        query: [],
+        remoteAddress: '10.20.30.55',
+      ),
     ];
     $responses = [
+      $this->createFakeOpenSwooleResponse(),
       $this->createFakeOpenSwooleResponse(),
       $this->createFakeOpenSwooleResponse(),
       $this->createFakeOpenSwooleResponse(),
@@ -867,6 +886,7 @@ class RuntimeCest
     $secondPayload = json_decode($responses[1]->body, true);
     $sessionWritePayload = json_decode($responses[2]->body, true);
     $sessionReadPayload = json_decode($responses[3]->body, true);
+    $sessionRegeneratePayload = json_decode($responses[4]->body, true);
 
     $I->assertSame(200, $responses[0]->status);
     $I->assertSame(200, $responses[1]->status);
@@ -890,6 +910,11 @@ class RuntimeCest
     $I->assertSame(['principal' => null], $sessionReadPayload);
     $I->assertStringContainsString('HttpOnly', $responses[2]->headers['Set-Cookie'] ?? '');
     $I->assertStringContainsString('SameSite=Lax', $responses[2]->headers['Set-Cookie'] ?? '');
+    $I->assertNotSame($sessionRegeneratePayload['previous'], $sessionRegeneratePayload['current']);
+    $I->assertStringStartsWith(
+      session_name() . '=' . rawurlencode($sessionRegeneratePayload['current']) . ';',
+      $responses[4]->headers['Set-Cookie'] ?? ''
+    );
     $I->assertSame(1, $this->readProtectedProperty($app, 'applicationGraphBuildCount'));
     $I->assertSame(1, $this->readProtectedProperty($app, 'middlewareBuildCount'));
     $I->assertNull(RuntimeContext::get(Request::class));

--- a/tests/Unit/SecurityCest.php
+++ b/tests/Unit/SecurityCest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Unit;
+
+use Assegai\Core\ExecutionContext;
+use Assegai\Core\Exceptions\Http\BadRequestException;
+use Assegai\Core\Http\Requests\Request;
+use Assegai\Core\Http\Requests\RuntimeRequestContext;
+use Assegai\Core\Interceptors\FileInterceptor;
+use Assegai\Core\Interceptors\FileInterceptorOptions;
+use Assegai\Core\Rendering\ViewProperties;
+use Assegai\Core\Runtimes\RuntimeContext;
+use ReflectionMethod;
+use Tests\Support\UnitTester;
+
+class SecurityCest
+{
+    public function _after(): void
+    {
+        RuntimeContext::flush();
+        Request::setInstance(null);
+    }
+
+    public function testDocumentPropertiesEscapeHtmlContexts(UnitTester $I): void
+    {
+        $properties = new ViewProperties(
+            title: '</title><script>audit()</script>',
+            meta: [
+                'props' => [
+                    "description' onmouseover='audit()" => "'><img src=x onerror=audit()>",
+                ],
+            ],
+            base: "' onfocus='audit()",
+        );
+
+        $html = (string)$properties;
+
+        $I->assertStringNotContainsString('<script>audit()</script>', $html);
+        $I->assertStringNotContainsString("onfocus='audit()'", $html);
+        $I->assertStringNotContainsString('<img src=x', $html);
+        $I->assertStringContainsString('&lt;script&gt;audit()&lt;/script&gt;', $html);
+    }
+
+    public function testFileInterceptorGeneratesContainedServerFilename(UnitTester $I): void
+    {
+        $tmpName = tempnam(sys_get_temp_dir(), 'assegai-upload-');
+        file_put_contents($tmpName, 'png-bytes');
+
+        try {
+            $request = $this->createRequestWithUpload($tmpName, '../../avatar.png', 9);
+            $interceptor = new FileInterceptor('avatar', new FileInterceptorOptions(
+                dest: '/srv/app/uploads',
+                fileFilter: static fn(array $file): bool => $file['extension'] === 'png',
+                limits: ['fileSize' => 1024],
+            ));
+
+            $interceptor->intercept($this->createExecutionContext());
+            $file = $request->getFile();
+
+            $I->assertSame('avatar.png', $file['original_name']);
+            $I->assertStringStartsWith('/srv/app/uploads/', $file['target_path']);
+            $I->assertStringNotContainsString('..', $file['target_path']);
+            $I->assertMatchesRegularExpression('/^[a-f0-9]{32}\.png$/', $file['stored_name']);
+        } finally {
+            if (is_string($tmpName) && is_file($tmpName)) {
+                unlink($tmpName);
+            }
+        }
+    }
+
+    public function testFileInterceptorEnforcesSizeLimitsAndExecutableExtensionBlocklist(UnitTester $I): void
+    {
+        $tmpName = tempnam(sys_get_temp_dir(), 'assegai-upload-');
+        file_put_contents($tmpName, 'payload');
+
+        try {
+            $this->createRequestWithUpload($tmpName, 'payload.png', 2048);
+            $I->expectThrowable(BadRequestException::class, function (): void {
+                (new FileInterceptor('avatar', new FileInterceptorOptions(limits: ['fileSize' => 3])))
+                    ->intercept($this->createExecutionContext());
+            });
+
+            $this->createRequestWithUpload($tmpName, 'shell.php', 7);
+            $I->expectThrowable(BadRequestException::class, function (): void {
+                (new FileInterceptor('avatar'))->intercept($this->createExecutionContext());
+            });
+        } finally {
+            if (is_string($tmpName) && is_file($tmpName)) {
+                unlink($tmpName);
+            }
+        }
+    }
+
+    private function createRequestWithUpload(string $tmpName, string $name, int $size): Request
+    {
+        RuntimeContext::flush();
+        $request = Request::createFromRuntimeContext(new RuntimeRequestContext(
+            server: [
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/upload',
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            rawBody: '{}',
+        ));
+        $request->setFile([
+            'avatar' => [
+                'name' => $name,
+                'tmp_name' => $tmpName,
+                'type' => 'application/octet-stream',
+                'error' => UPLOAD_ERR_OK,
+                'size' => $size,
+            ],
+        ]);
+        Request::setInstance($request);
+        RuntimeContext::set(Request::class, $request);
+
+        return $request;
+    }
+
+    private function createExecutionContext(): ExecutionContext
+    {
+        return new ExecutionContext(self::class, new ReflectionMethod($this, 'noop'));
+    }
+
+    private function noop(): void
+    {
+    }
+}

--- a/tests/Unit/_bootstrap.php
+++ b/tests/Unit/_bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+$sessionDirectory = sys_get_temp_dir() . '/assegaiphp-core-session-tests';
+
+if (!is_dir($sessionDirectory)) {
+    mkdir($sessionDirectory, 0777, true);
+}
+
+session_save_path($sessionDirectory);


### PR DESCRIPTION
This pull request introduces several important improvements to documentation, error handling, and security practices in the framework. The most significant changes include stricter and safer error handling for production environments, enhanced documentation around security and configuration, and improved handling of session and proxy state. Several outdated PHPStan baseline suppressions were also removed, reflecting improvements in code quality.

**Error handling and runtime safety:**

* Introduced a dedicated `DefaultErrorHandler` for production environments and updated the error handling flow to use environment-specific handlers, ensuring safer error reporting in production (`src/App.php`). [[1]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR16) [[2]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR120-R123) [[3]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR223) [[4]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fL233-R258)
* Improved session management by ensuring session cookie headers are handled correctly and session state is properly cleared between requests, especially in long-lived runtimes (`src/App.php`). [[1]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR170) [[2]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR389) [[3]](diffhunk://#diff-ad46c7350003ccf7f086dccbecc6fcb7706a1558b14eb5e437a856b8c619e71fR401-R409)

**Documentation and security guidance:**

* Added warnings and best practices for handling untrusted file uploads, clarifying how `FileInterceptor` normalizes and validates uploaded files (`docs/controllers-and-routing.md`).
* Expanded documentation for proxy-aware host resolution, emphasizing the importance of trusting only specific proxy IPs and ignoring untrusted forwarded headers by default (`docs/controllers-and-routing.md`).
* Documented default session cookie security settings and session isolation in long-lived runtimes (`docs/authentication.md`).

**Configuration and runtime documentation:**

* Clarified that runtime API documentation is disabled by default and must be explicitly enabled, and explained how to protect documentation endpoints with middleware (`docs/api-docs-and-clients.md`). [[1]](diffhunk://#diff-f2a52a92218d8ed72e68c828a720d0fe9dc664b9a833cf5b7b5e67d6b0df4cb0L56-R56) [[2]](diffhunk://#diff-f2a52a92218d8ed72e68c828a720d0fe9dc664b9a833cf5b7b5e67d6b0df4cb0L66-R66) [[3]](diffhunk://#diff-f2a52a92218d8ed72e68c828a720d0fe9dc664b9a833cf5b7b5e67d6b0df4cb0R81-R82)
* Updated OpenSwoole configuration to require `enableCoroutine: false` for safe request handling, with clear documentation on why coroutine support is disabled (`docs/openswoole-runtime.md`, `docs/serving-with-openswoole.md`). [[1]](diffhunk://#diff-01835dc8d3c864c77652924b37de7927ef628a1ed49055cb97d70a547d2d6466L45-R45) [[2]](diffhunk://#diff-01835dc8d3c864c77652924b37de7927ef628a1ed49055cb97d70a547d2d6466R63-R64) [[3]](diffhunk://#diff-637bb2603a8d7f5233d45dbf84f98ce3be39f03f87e3b6465ace2823885113e4L65-R65) [[4]](diffhunk://#diff-637bb2603a8d7f5233d45dbf84f98ce3be39f03f87e3b6465ace2823885113e4L86-R86)

**Code quality:**

* Removed several obsolete PHPStan baseline suppressions, reflecting improvements in code correctness (`phpstan-baseline.neon`). [[1]](diffhunk://#diff-995edee38ad4f8387e58ebd52c31bcc04c56cc2448d331b1cf5e0b35c57b9efaL53-L57) [[2]](diffhunk://#diff-995edee38ad4f8387e58ebd52c31bcc04c56cc2448d331b1cf5e0b35c57b9efaL625-L629) [[3]](diffhunk://#diff-995edee38ad4f8387e58ebd52c31bcc04c56cc2448d331b1cf5e0b35c57b9efaL655-L669) [[4]](diffhunk://#diff-995edee38ad4f8387e58ebd52c31bcc04c56cc2448d331b1cf5e0b35c57b9efaL975-L979)

**Minor code and doc fixes:**

* Cleaned up redundant path parsing logic in `index.php` and related documentation (`README.md`, `docs/getting-started.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-L53) [[2]](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L112-L114)
* Ensured debug mode is set via `Config::isDebug()` for consistency (`src/App.php`).
* Adjusted the order of middleware and API docs handling for more predictable routing (`src/App.php`).