### PR TITLE
Add release notes for version 0.9.4 highlighting key improvements

### DIFF
--- a/docs/releases/0.9.4-release-notes.md
+++ b/docs/releases/0.9.4-release-notes.md
@@ -1,0 +1,96 @@
+# AssegaiPHP Core 0.9.4
+
+Released: 2026-07-22
+
+`0.9.4` is a runtime correctness and security-hardening release for Core.
+
+This release improves host-scoped routing and OpenAPI metadata, makes long-lived session handling safe across sequential requests, strengthens request and upload boundaries, and makes error handling and value hydration more predictable.
+
+## Highlights
+
+### Correct host scopes across module boundaries
+
+Core now carries effective host constraints through nested and imported module graphs instead of treating a controller's local host declaration as the whole routing scope.
+
+This fixes several related cases:
+
+- imported controllers inherit the host scope of their parent module
+- host-scoped controllers do not accidentally restrict hostless siblings
+- the closest matching controller wins in deeply nested dynamic routes
+- host-scoped imported routes take precedence over generic root fallbacks when appropriate
+
+Generated OpenAPI operations now use the same effective host groups as runtime routing. Inherited host variables and server URLs remain attached to imported routes, and generating metadata for another root module in the same process rebuilds the relevant controller graph.
+
+### Safer request and runtime boundaries
+
+Forwarded host and scheme headers are ignored unless the request came through an explicitly trusted proxy. Applications can configure exact proxy addresses or CIDR ranges through `trustedProxies`, or supply a comma-separated `TRUSTED_PROXIES` environment value.
+
+The request URI is now authoritative when `REQUEST_URI` is available. A query parameter named `path` can no longer replace it, preventing query data from selecting a different route than the web server requested.
+
+Runtime API documentation is now disabled by default and must be enabled explicitly with `apiDocs.enabled`. When enabled, `/docs` and `/openapi.json` pass through the application's configured middleware.
+
+OpenSwoole coroutine request handling is rejected for now. PHP superglobals and session state are process-global, so `enableCoroutine` must remain `false` until concurrent request state can be isolated safely.
+
+### Reliable sessions in long-lived workers
+
+Session cookies now use secure framework defaults:
+
+- `HttpOnly` is enabled by default
+- `SameSite=Lax` is the default policy
+- `Secure` is enabled automatically for HTTPS requests
+- cookie lifetime, path, domain, security, and SameSite behavior remain configurable
+
+Long-lived runtimes isolate the session identifier and `$_SESSION` data between requests. Cookie headers are derived from the final session ID when a request closes, so `session_regenerate_id()` no longer leaves clients using the previous ID.
+
+Environment detection also accepts common `APP_ENV` and `APP_DEBUG` aliases without framework defaults shadowing them. Values are read consistently from `$_ENV`, `$_SERVER`, and the process environment.
+
+### Hardened uploads and document rendering
+
+`FileInterceptor` now treats browser-supplied upload metadata as untrusted. It normalizes the original filename, measures the temporary file when available, derives its MIME type, enforces configured size and filter rules, blocks executable extensions, and generates a random server-side filename contained within the configured destination.
+
+Rendered document properties now escape titles, base URLs, favicon values, link attributes, and script attributes for their HTML contexts. Link definitions also support structured attribute maps while retaining the existing string and positional forms.
+
+### Production-safe error handling
+
+PHP runtime errors now use the production-safe handler in production and the detailed development handler elsewhere. Handled failures are logged with more useful context, including throwable chains where available, while production responses continue to avoid exposing internal paths and diagnostics.
+
+Framework exception types now preserve their previous throwable, allowing logs to retain the root-cause chain without changing the public response contract.
+
+### More predictable value hydration
+
+`TypeManager` now handles decoded JSON structures more consistently:
+
+- nested objects can hydrate DTO properties
+- decoded objects can be converted to arrays where the target permits arrays
+- nullable date properties preserve `null`
+- compatible union types accept decoded object structures
+- scalar properties reject object values instead of silently coercing them
+
+These changes make request DTO hydration stricter at invalid boundaries while supporting the nested shapes that valid JSON payloads naturally produce.
+
+## Upgrade Notes
+
+No application-wide migration is required, but applications using the affected features should review these changes:
+
+- Runtime API docs are disabled by default. Set `apiDocs.enabled` to `true` to expose `/docs` and `/openapi.json`, and ensure the configured middleware applies the intended access controls.
+- Forwarded host and scheme headers are trusted only from configured proxies. Add proxy IP addresses or CIDR ranges to `trustedProxies`, or set `TRUSTED_PROXIES` in the process environment.
+- OpenSwoole configurations must keep `enableCoroutine` set to `false`.
+- Front controllers should derive `$_GET['path']` from `REQUEST_URI` unconditionally when using the legacy path bridge. Query-string `path` values no longer override a real request URI.
+- Upload consumers should use `original_name` for the normalized client filename and `stored_name` or `target_path` for server-side storage. Do not assume that the original filename is used on disk.
+- Tests that assert exact error text, and integrations that depend on object-to-scalar coercion, should be updated for the safer behavior.
+
+## Validation
+
+This release adds or updates regression coverage for:
+
+- inherited host scopes across nested and imported modules
+- deep dynamic route resolution and hostless sibling routing
+- OpenAPI servers generated from effective host constraints
+- production-safe PHP error handling and throwable-chain logging
+- nested DTO, array, date, union, and scalar hydration
+- HTML escaping and structured link attributes
+- trusted proxy address and CIDR matching
+- request URI precedence over query parameters
+- API documentation defaults and middleware execution
+- upload filename containment, size limits, MIME inspection, filters, and executable-extension rejection
+- secure session cookie defaults, request isolation, and regenerated session IDs


### PR DESCRIPTION
This pull request adds the release notes for AssegaiPHP Core version 0.9.4. The release focuses on runtime correctness and security improvements, especially around host-scoped routing, OpenAPI metadata, request/session handling, error handling, and value hydration.

Key updates in this release:

**Routing and API documentation:**
* Host constraints are now correctly inherited through module boundaries, fixing routing issues with imported and nested controllers. OpenAPI metadata generation now matches the effective host groups used at runtime.
* Runtime API documentation endpoints (`/docs`, `/openapi.json`) are now disabled by default and must be explicitly enabled.

**Security and request handling:**
* Forwarded host and scheme headers are only trusted from explicitly configured proxies, set via `trustedProxies` or the `TRUSTED_PROXIES` environment variable.
* The request URI is now authoritative, preventing query parameters from overriding the actual route.
* OpenSwoole coroutine request handling is disabled to prevent unsafe concurrent session and superglobal state.

**Session and upload hardening:**
* Session cookies now use secure defaults (`HttpOnly`, `SameSite=Lax`, `Secure` for HTTPS) and session state is reliably isolated between requests in long-lived runtimes.
* Upload handling